### PR TITLE
Cleanup: Remove command added to debug ssh setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,10 +70,7 @@ jobs:
 
       - run:
           name: add known hosts
-          command: |
-            ls ~/.ssh
-            chmod 600 ~/.ssh/id_*
-            echo $KNOWN_HOSTS >> ~/.ssh/known_hosts
+          command: echo $KNOWN_HOSTS >> ~/.ssh/known_hosts
 
       - run:
           name: deploy script


### PR DESCRIPTION
`chmod`ing the identity file is unnecessary as CircleCI does it automatically in the `add_ssh_keys` step.

- [x] Confirmed that deployment works: https://circleci.com/gh/nilenso/leaflike/183