### PR TITLE
Tags [DB & migrations]

### DIFF
--- a/resources/migrations/006-alter-bookmark-tags.edn
+++ b/resources/migrations/006-alter-bookmark-tags.edn
@@ -1,0 +1,4 @@
+{:up ["ALTER TABLE bookmarks DROP COLUMN tags;
+       ALTER TABLE bookmarks ADD COLUMN tags text[];"]
+ :down ["ALTER TABLE bookmarks DROP COLUMN tags;
+         ALTER TABLE bookmarks ADD COLUMN tags text;"]}

--- a/src/leaflike/bookmarks/db.clj
+++ b/src/leaflike/bookmarks/db.clj
@@ -12,9 +12,8 @@
   ;; check if tags is nil?
   (if (nil? tags)
     params
-    (do ;; :tags "space space , comma . dot"
-        (str/split tags #"(\w)(\s+)([\.,])")
-        (assoc params :tags (types/array tags)))))
+    (let [tags (str/split tags #",")]
+      (assoc params :tags (types/array tags)))))
 
 (defn create
   [params]

--- a/src/leaflike/bookmarks/db.clj
+++ b/src/leaflike/bookmarks/db.clj
@@ -12,7 +12,8 @@
   ;; check if tags is nil?
   (if (nil? tags)
     params
-    (do (str/split tags #"(\w)(\s+)([\.,])")
+    (do ;; :tags "space space , comma . dot"
+        (str/split tags #"(\w)(\s+)([\.,])")
         (assoc params :tags (types/array tags)))))
 
 (defn create

--- a/src/leaflike/bookmarks/db.clj
+++ b/src/leaflike/bookmarks/db.clj
@@ -6,10 +6,10 @@
             [honeysql.types :as types]))
 
 (defn format-tags
-  [params]
+  [{:keys [tags] :as params}]
   ;; check if tag exists
   ;; check if tags is nil?
-  (if (nil? (get params :tags))
+  (if (nil? tags)
     params
     (update params :tags #(types/array %))))
 

--- a/src/leaflike/bookmarks/db.clj
+++ b/src/leaflike/bookmarks/db.clj
@@ -2,14 +2,23 @@
   (:require [clojure.java.jdbc :as jdbc]
             [leaflike.config :refer [db-spec]]
             [honeysql.core :as sql]
-            [honeysql.helpers :as helpers]))
+            [honeysql.helpers :as helpers]
+            [honeysql.types :as types]))
+
+(defn format-tags
+  [params]
+  ;; check if tag exists
+  ;; check if tags is nil?
+  (if (nil? (get params :tags))
+    params
+    (update params :tags #(types/array %))))
 
 (defn create
   [params]
   (jdbc/execute! (db-spec) (-> (helpers/insert-into :bookmarks)
-                               (helpers/values [params])
-                               sql/format)))
-
+                               (helpers/values [(format-tags params)])
+                                sql/format)))
+  
 (defn list-all
   [{:keys [member_id]}]
   (jdbc/query (db-spec) (-> (helpers/select :*)

--- a/src/leaflike/bookmarks/db.clj
+++ b/src/leaflike/bookmarks/db.clj
@@ -1,9 +1,10 @@
 (ns leaflike.bookmarks.db
   (:require [clojure.java.jdbc :as jdbc]
-            [leaflike.config :refer [db-spec]]
-            [honeysql.core :as sql]
-            [honeysql.helpers :as helpers]
-            [honeysql.types :as types]))
+            [honeysql.core     :as sql]
+            [honeysql.helpers  :as helpers]
+            [honeysql.types    :as types]
+            [clojure.string    :as str]
+            [leaflike.config   :refer [db-spec]]))
 
 (defn format-tags
   [{:keys [tags] :as params}]
@@ -11,7 +12,8 @@
   ;; check if tags is nil?
   (if (nil? tags)
     params
-    (update params :tags #(types/array %))))
+    (do (str/split tags #"(\w)(\s+)([\.,])")
+        (assoc params :tags (types/array tags)))))
 
 (defn create
   [params]

--- a/test/leaflike/functional/bookmarks.clj
+++ b/test/leaflike/functional/bookmarks.clj
@@ -12,7 +12,7 @@
 
 (def bookmark {:title "abc"
                :url   "http://abc.com"
-               :tags  "abc random test, music . something"})
+               :tags  "abc, random, test, music, something"})
 
 (defn make-request
   ([params body]

--- a/test/leaflike/functional/bookmarks.clj
+++ b/test/leaflike/functional/bookmarks.clj
@@ -12,7 +12,7 @@
 
 (def bookmark {:title "abc"
                :url   "http://abc.com"
-               :tags  ["abc" "random" "test"]})
+               :tags  "abc random test, music . something"})
 
 (defn make-request
   ([params body]

--- a/test/leaflike/functional/bookmarks.clj
+++ b/test/leaflike/functional/bookmarks.clj
@@ -12,7 +12,7 @@
 
 (def bookmark {:title "abc"
                :url   "http://abc.com"
-               :tags  "abc, random, test"})
+               :tags  ["abc" "random" "test"]})
 
 (defn make-request
   ([params body]

--- a/test/leaflike/unit/bookmarks_validation.clj
+++ b/test/leaflike/unit/bookmarks_validation.clj
@@ -43,7 +43,7 @@
       (not (valid-bookmark? a))))
 
   (testing "is bookmark valid with tags"
-    (let [a {:url "http://google.com" :title "google" :tags "information"}]
+    (let [a {:url "http://google.com" :title "google" :tags ["information"]}]
       (is (valid-bookmark? a))))
 
   (testing "is bookmark valid with id?"

--- a/test/leaflike/unit/bookmarks_validation.clj
+++ b/test/leaflike/unit/bookmarks_validation.clj
@@ -43,7 +43,7 @@
       (not (valid-bookmark? a))))
 
   (testing "is bookmark valid with tags"
-    (let [a {:url "http://google.com" :title "google" :tags ["information"]}]
+    (let [a {:url "http://google.com" :title "google" :tags "information something"}]
       (is (valid-bookmark? a))))
 
   (testing "is bookmark valid with id?"


### PR DESCRIPTION
Earlier tags were saved as text field, now it is a text[] field.
This helps in storing the tags as an array of strings

* tests were breaking; have been fixed
* added required validation to convert array to sql/array
* migration file is added