### PR TITLE
Fix `alpha-num-pattern` regex & fix typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ $ git clone https://github.com/nilenso/leaflike.git
 #### Setup Databases
 
 ```
-$ createdb -U username leaflike
-$ createdb -U username leaflike_test
+$ createdb -U <username> leaflike
+$ createdb -U <username> leaflike_test
 ```
 
-**Note : Change postgres username and password in config.end.test and config.end.dev if required**
+**Note : Change postgres username and password in `config.edn.test` and `config.edn.dev` if required**
 
 #### Run Tests
 

--- a/src/leaflike/utils.clj
+++ b/src/leaflike/utils.clj
@@ -4,7 +4,7 @@
 
 (def email-pattern #"[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?")
 
-(def alpha-num-pattern #"^[a-zA-Z]+$")
+(def alpha-num-pattern #"^[a-zA-Z0-9]+$")
 
 (defn get-timestamp
   []


### PR DESCRIPTION
Fixes #35, #45 and #46.

- Change `leaflike.utils/alpha-num-pattern` regex to accept numeric
  characters.
- Fix typo("end" -> "edn")
- Clarify in README that "username" is something the user needs to
  change.