### PR TITLE
Implement pagination for list of bookmarks; fix redirections

### DIFF
--- a/src/leaflike/bookmarks/core.clj
+++ b/src/leaflike/bookmarks/core.clj
@@ -22,35 +22,30 @@
       (let [bookmark (assoc body
                             :member_id (:id user)
                             :created_at (utils/get-timestamp))]
-        {:result (bm-db/create bookmark)
-         :error false})
-      {:error true
-       :result "Invalid params"})))
+        (bm-db/create bookmark))
+      (throw (ex-info "Invalid params" {:bookmark body})))))
 
 (defn list-all
   [request]
   (let [params {:member_id (:id (get-user request))}]
-    {:result  (bm-db/list-all params)
-     :error   false}))
+    (bm-db/list-all params)))
 
 (defn fetch-bookmarks
   [request]
   (let [items-per-page 10
         page (Integer/parseInt (get-in request [:params :page]))
-        page (dec page)
         user (get-user request)]
-    (if (>= page 0)
-      (let [bookmarks (bm-db/fetch-bookmarks {:member_id (:id user)
+    (if (>= page 1)
+      (let [page (dec page)
+            bookmarks (bm-db/fetch-bookmarks {:member_id (:id user)
                                               :limit items-per-page
                                               :offset (* items-per-page page)})
             num-bookmarks (-> (bm-db/count-bookmarks {:member_id (:id user)})
                               first
                               :count)]
-        {:result {:bookmarks bookmarks
-                  :num-pages (/ num-bookmarks items-per-page)}
-         :error false})
-      {:error true
-       :result "Invalid page number"})))
+        {:bookmarks bookmarks
+         :num-pages (/ num-bookmarks items-per-page)})
+      (throw (ex-info "Invalid page number" {:page page})))))
 
 (defn list-by-id
   [request]
@@ -58,10 +53,8 @@
         user      (get-user request)
         params    {:id id :member_id (:id user)}]
     (if (id? params)
-      {:result  (bm-db/list-by-id params)
-       :error   false}
-      {:error  true
-       :result "Invalid params"})))
+      (bm-db/list-by-id params)
+      (throw (ex-info "Invalid id" {:id id})))))
 
 (defn delete
   [request]
@@ -69,7 +62,5 @@
         user      (get-user request)
         params    {:id id :member_id (:id user)}]
     (if (id? params)
-      {:result (bm-db/delete params)
-       :error  false}
-      {:error  true
-       :result "Invalid params"})))
+      (bm-db/delete params)
+      (throw (ex-info "Invalid id" {:id id})))))

--- a/src/leaflike/bookmarks/core.clj
+++ b/src/leaflike/bookmarks/core.clj
@@ -33,6 +33,25 @@
     {:result  (bm-db/list-all params)
      :error   false}))
 
+(defn fetch-bookmarks
+  [request]
+  (let [items-per-page 10
+        page (Integer/parseInt (get-in request [:params :page]))
+        page (dec page)
+        user (get-user request)]
+    (if (>= page 0)
+      (let [bookmarks (bm-db/fetch-bookmarks {:member_id (:id user)
+                                              :limit items-per-page
+                                              :offset (* items-per-page page)})
+            num-bookmarks (-> (bm-db/count-bookmarks {:member_id (:id user)})
+                              first
+                              :count)]
+        {:result {:bookmarks bookmarks
+                  :num-pages (/ num-bookmarks items-per-page)}
+         :error false})
+      {:error true
+       :result "Invalid page number"})))
+
 (defn list-by-id
   [request]
   (let [id        (get-in request [:route-params :id])

--- a/src/leaflike/bookmarks/db.clj
+++ b/src/leaflike/bookmarks/db.clj
@@ -20,12 +20,30 @@
   (jdbc/execute! (db-spec) (-> (helpers/insert-into :bookmarks)
                                (helpers/values [(format-tags params)])
                                 sql/format)))
-  
+
 (defn list-all
   [{:keys [member_id]}]
   (jdbc/query (db-spec) (-> (helpers/select :*)
                             (helpers/from :bookmarks)
                             (helpers/where [:= :member_id member_id])
+                            sql/format)))
+
+(defn count-bookmarks
+  "Return number of bookmarks the user has."
+  [{:keys [member_id]}]
+  (jdbc/query (db-spec) (-> (helpers/select :%count.*)
+                            (helpers/from :bookmarks)
+                            (helpers/where [:= :member_id member_id])
+                            sql/format)))
+
+(defn fetch-bookmarks
+  "Fetch a `limit` number of bookmarks starting from `offset`."
+  [{:keys [member_id limit offset] :or {offset 0}}]
+  (jdbc/query (db-spec) (-> (helpers/select :*)
+                            (helpers/from :bookmarks)
+                            (helpers/where [:= :member_id member_id])
+                            (helpers/limit limit)
+                            (helpers/offset offset)
                             sql/format)))
 
 (defn list-by-id

--- a/src/leaflike/bookmarks/routes.clj
+++ b/src/leaflike/bookmarks/routes.clj
@@ -30,8 +30,13 @@
 
 (defn list-all-view
   [request]
-  (let [bookmarks (:result (bm-core/list-all request))]
-    (-> (res/response (application "Bookmarks" (views/list-all bookmarks)))
+  (res/redirect "/bookmarks/page/1"))
+
+;;; TODO: convert all underscore's to hyphens
+(defn list-bookmarks-view
+  [request]
+  (let [{:keys [bookmarks num-pages]} (bm-core/fetch-bookmarks request)]
+    (-> (res/response (application "Bookmarks" (views/list-all bookmarks num-pages)))
         (assoc :headers {"Content-Type" "text/html"}))))
 
 (defn create-view
@@ -43,4 +48,6 @@
 (def bookmarks-routes
   {"bookmarks" {"" (with-auth-middlewares {:get  list-all-view
                                            :post create})
+                ["/page/" :page] (with-auth-middlewares
+                                  {:get list-bookmarks-view})
                 "/add" (with-auth-middlewares {:get create-view})}})

--- a/src/leaflike/bookmarks/routes.clj
+++ b/src/leaflike/bookmarks/routes.clj
@@ -10,11 +10,8 @@
 (defn create
   [request]
   (let [result (bm-core/create request)]
-    ;; error : false means bookmarks is created ^_^
-    (if-not (:error result)
-      (-> (res/redirect "/bookmarks")
-          (assoc-in [:headers "Content-Type"] "text/html"))
-      (res/response result))))
+    (-> (res/redirect "/bookmarks")
+        (assoc-in [:headers "Content-Type"] "text/html"))))
 
 #_(defn list-all
   [request]
@@ -49,5 +46,5 @@
   {"bookmarks" {"" (with-auth-middlewares {:get  list-all-view
                                            :post create})
                 ["/page/" :page] (with-auth-middlewares
-                                  {:get list-bookmarks-view})
+                                   {:get list-bookmarks-view})
                 "/add" (with-auth-middlewares {:get create-view})}})

--- a/src/leaflike/bookmarks/views.clj
+++ b/src/leaflike/bookmarks/views.clj
@@ -2,7 +2,7 @@
   (:require [hiccup.form :as f]))
 
 (defn list-all
-  [bookmarks]
+  [bookmarks num-pages]
   [:div {:id "content"}
    [:div {:class "row"}
     [:div {:class "col"}
@@ -13,17 +13,20 @@
    [:table {:class "table"}
     [:thead {:class "thead-dark"}
      [:tr
-      [:th {:scope "col"} "Id"]
       [:th {:scope "col"} "Title"]
       [:th {:scope "col"} "Tags"]
       [:th {:scope "col"} "Date"]]]
     [:tbody
      (for [bookmark bookmarks]
        [:tr
-        [:th {:scope "row"} (:id bookmark)]
         [:td [:a {:href (:url bookmark)} (:title bookmark)]]
         [:td (:tags bookmark)]
-        [:td (:created_at bookmark)]])]]])
+        [:td (:created_at bookmark)]])]]
+
+   [:table {:class "table"}
+    (for [i (range num-pages)]
+      [:td {:scope "col"}
+       [:a {:href (str "/bookmarks/page/" (inc i))} (inc i)]])]])
 
 (defn add-bookmark
   [anti-forgery-token]

--- a/src/leaflike/dev/sample_data.clj
+++ b/src/leaflike/dev/sample_data.clj
@@ -22,7 +22,7 @@
   "Adds `bookmark` as `username`."
   [username bookmark]
   (bm-core/create {:params bookmark
-                   :session {:username username}}))
+                   :username username}))
 
 (defn- add-n-bookmarks
   "Adds `num-bookmarks` generated bookmarks as `username`."

--- a/src/leaflike/middlewares.clj
+++ b/src/leaflike/middlewares.clj
@@ -1,13 +1,21 @@
 (ns leaflike.middlewares
   (:require [clojure.algo.generic.functor :refer [fmap]]
-            [leaflike.user.auth :refer [wrap-authorization
-                                        wrap-auth-response]]))
+            [leaflike.user.auth :refer [wrap-authorization]])
+  (:import clojure.lang.ExceptionInfo))
+
+(defn wrap-exception-handling
+  "Catches an exception and returns the appropriate HTTP response."
+  [handler-fn]
+  (fn [request]
+    (try (handler-fn request)
+         (catch ExceptionInfo e
+           {:status 400
+            :body (.getMessage e)}))))
 
 (defn auth-middleware
   [handler-fn]
   (-> handler-fn
-      wrap-authorization
-      wrap-auth-response))
+      wrap-authorization))
 
 (defn with-auth-middlewares
   [route-map]

--- a/src/leaflike/server.clj
+++ b/src/leaflike/server.clj
@@ -3,6 +3,7 @@
             [leaflike.routes                :refer [home-routes]]
             [leaflike.bookmarks.routes      :refer [bookmarks-routes]]
             [leaflike.user.routes           :refer [user-routes]]
+            [leaflike.middlewares :as middlewares]
             [bidi.ring                      :as    bidi]
             [org.httpkit.server             :as    httpkit]
             [ring.middleware.resource       :refer [wrap-resource]]
@@ -24,6 +25,7 @@
 (defn app
   []
   (-> app-handler
+      middlewares/wrap-exception-handling
       wrap-anti-forgery
       (wrap-resource "public")
       (wrap-json-params {:keywords? true :bigdecimals? true})

--- a/src/leaflike/user/db.clj
+++ b/src/leaflike/user/db.clj
@@ -24,7 +24,7 @@
   ([identifier coll]
    (jdbc/query (db-spec) (-> (helpers/select coll)
                              (helpers/from :members)
-                             (helpers/where [:= :username (name identifier)])
+                             (helpers/where [:= :username identifier])
                              sql/format))))
 
 (defn create-user

--- a/src/leaflike/user/routes.clj
+++ b/src/leaflike/user/routes.clj
@@ -15,17 +15,16 @@
   ;; authenticate
   (user-core/login request))
 
-
 (defn logout
   [request]
   ;; logout
   (user-core/logout request))
 
 (defn login-page
-  [request]
+  [{{:strs [next]} :query-params :as request}]
   (-> (res/response (layout/application 
-                        "Login" 
-                        (views/login-form anti-forgery/*anti-forgery-token*)))
+                     "Login"
+                     (views/login-form anti-forgery/*anti-forgery-token* :next-url next)))
       (assoc :headers {"Content-Type" "text/html"})
       (assoc :status 200)))
 
@@ -41,7 +40,7 @@
   {;; existing user
    "login"        {:post login
                    :get  login-page}
-   "logout"       (with-auth-middlewares  {:post logout})
+   "logout"       (with-auth-middlewares  {:get logout})
    ;; new user
    "signup"       {:post signup
                    :get  signup-page}})

--- a/src/leaflike/user/views.clj
+++ b/src/leaflike/user/views.clj
@@ -3,12 +3,12 @@
             [hiccup.element :refer [link-to]]))
 
 (defn login-form
-  [anti-forgery-token]
+  [anti-forgery-token & {:keys [next-url]}]
   [:div {:id "content"}
    [:h3 {:class "text-success"} "Login"]
    [:div {:class "well well-width"}
     (f/form-to {:role "form" :novalidate ""}
-               [:post "/login"]
+               [:post (str "/login?next=" next-url)]
                [:div {:class "form-group"}
                 (f/label {:class "control-label"} "username" "Username")
                 (f/text-field {:class "form-control" :placeholder "Username"} "username")]

--- a/test/leaflike/functional/bookmarks.clj
+++ b/test/leaflike/functional/bookmarks.clj
@@ -2,7 +2,8 @@
   (:require [leaflike.bookmarks.core :as bm-core]
             [leaflike.fixtures :refer [wrap-setup]]
             [clojure.test :refer :all]
-            [leaflike.user.core :as user-core]))
+            [leaflike.user.core :as user-core])
+  (:import clojure.lang.ExceptionInfo))
 
 (use-fixtures :once wrap-setup)
 
@@ -28,50 +29,42 @@
     :route-params route-params}))
 
 (deftest bookmark-tests
-   (user-core/signup (make-request user {}))
+  (user-core/signup (make-request user {}))
 
   (testing "create bookmark success"
     (let [response (bm-core/create (make-request bookmark {}))]
-      (is (and (= false (:error response))
-               (= '(1) (:result response))))))
+      (is (= '(1) response))))
 
-    (testing "create bookmark success without tags"
-      (let [response (bm-core/create (make-request (dissoc bookmark :tags) {}))]
-        (is (and (= false (:error response))
-                 (= '(1) (:result response))))))
+  (testing "create bookmark success without tags"
+    (let [response (bm-core/create (make-request (dissoc bookmark :tags) {}))]
+      (is (= '(1) response))))
 
   (testing "create bookmark failed"
-    (let [response (bm-core/create (make-request (dissoc bookmark :url) {}))]
-      (is (and (:error response)
-               (= "Invalid params" (:result response))))))
+    (is (thrown-with-msg? ExceptionInfo #"Invalid params"
+                          (bm-core/create (make-request (dissoc bookmark :url) {})))))
 
   (testing "list all bookmarks"
     (let [response (bm-core/list-all (make-request {} {}))]
-      (is (= 2 (count (:result response))))
+      (is (= 2 (count response)))
       ;; todo - array selective equals
       ))
 
   (testing "list bookmark by id, wrong input in id"
-    (let [response (bm-core/list-by-id (make-request {:id "2abc"}))]
-      (is (and (:error response)
-               (= "Invalid params" (:result response))))))
+    (is (thrown-with-msg? ExceptionInfo #"Invalid id"
+                          (bm-core/list-by-id (make-request {:id "2abc"})))))
 
   (testing "list bookmark by id"
     (let [response (bm-core/list-by-id (make-request {:id "1"}))]
-      (is (and (= false (:error response))
-               (= 1 (count (:result response)))))))
+      (is (= 1 (count response)))))
 
   (testing "delete bookmark"
     (let [response (bm-core/delete (make-request {:id "1"}))]
-      (is (and (= false (:error response))
-               (= '(1) (:result response))))))
+      (is (= '(1) response))))
 
   (testing "delete bookmark failed, invalid input"
-    (let [response (bm-core/delete (make-request {:id "1jgk"}))]
-      (is (and (:error response)
-               (= "Invalid params" (:result response))))))
+    (is (thrown-with-msg? ExceptionInfo #"Invalid id"
+                          (bm-core/delete (make-request {:id "1jgk"})))))
 
   (testing "delete bookmark"
     (let [response (bm-core/delete (make-request {:id "31"}))]
-      (is (and (= false (:error response))
-               (= '(0) (:result response)))))))
+      (is (= '(0) response)))))

--- a/test/leaflike/functional/bookmarks.clj
+++ b/test/leaflike/functional/bookmarks.clj
@@ -15,56 +15,51 @@
                :url   "http://abc.com"
                :tags  "abc, random, test, music, something"})
 
-(defn make-request
-  ([params body]
-   {:params params
-    :body body
-    :session nil
-    :query-params {:next nil}})
-  ([route-params]
-   {:params nil
-    :body nil
-    :session nil
-    :query-params {:next nil}
-    :route-params route-params}))
-
 (deftest bookmark-tests
-  (user-core/signup (make-request user {}))
+  (user-core/signup {:params user})
 
   (testing "create bookmark success"
-    (let [response (bm-core/create (make-request bookmark {}))]
+    (let [response (bm-core/create {:params bookmark
+                                    :username (:username user)})]
       (is (= '(1) response))))
 
   (testing "create bookmark success without tags"
-    (let [response (bm-core/create (make-request (dissoc bookmark :tags) {}))]
+    (let [response (bm-core/create {:params (dissoc bookmark :tags)
+                                    :username (:username user)})]
       (is (= '(1) response))))
 
   (testing "create bookmark failed"
     (is (thrown-with-msg? ExceptionInfo #"Invalid params"
-                          (bm-core/create (make-request (dissoc bookmark :url) {})))))
+                          (bm-core/create {:params (dissoc bookmark :url)
+                                           :username (:username user)}))))
 
   (testing "list all bookmarks"
-    (let [response (bm-core/list-all (make-request {} {}))]
+    (let [response (bm-core/list-all {:username (:username user)})]
       (is (= 2 (count response)))
       ;; todo - array selective equals
       ))
 
   (testing "list bookmark by id, wrong input in id"
     (is (thrown-with-msg? ExceptionInfo #"Invalid id"
-                          (bm-core/list-by-id (make-request {:id "2abc"})))))
+                          (bm-core/list-by-id {:route-params {:id "2abc"}
+                                               :username (:username user)}))))
 
   (testing "list bookmark by id"
-    (let [response (bm-core/list-by-id (make-request {:id "1"}))]
+    (let [response (bm-core/list-by-id {:route-params {:id "1"}
+                                        :username (:username user)})]
       (is (= 1 (count response)))))
 
   (testing "delete bookmark"
-    (let [response (bm-core/delete (make-request {:id "1"}))]
+    (let [response (bm-core/delete {:route-params {:id "1"}
+                                    :username (:username user)})]
       (is (= '(1) response))))
 
   (testing "delete bookmark failed, invalid input"
     (is (thrown-with-msg? ExceptionInfo #"Invalid id"
-                          (bm-core/delete (make-request {:id "1jgk"})))))
+                          (bm-core/delete {:route-params {:id "1jgk"}
+                                           :username (:username user)}))))
 
   (testing "delete bookmark"
-    (let [response (bm-core/delete (make-request {:id "31"}))]
+    (let [response (bm-core/delete {:route-params {:id "31"}
+                                    :username (:username user)})]
       (is (= '(0) response)))))


### PR DESCRIPTION
Pagination:
- Break down list of bookmarks into pages(with 10 bookmarks/page)
- Routes are of the form `/bookmarks/page/1`.

Redirection fixes:
- When user is not logged in and tries to access a page that requires authorization, redirect to /login.
- Set `next` query parameter when redirecting to /login so that the user is redirected to the page he/she wanted to access earlier.