### PR TITLE
Miscellaneous fixes

### DIFF
--- a/resources/migrations/007-alter-bookmark-not-null-member-id.edn
+++ b/resources/migrations/007-alter-bookmark-not-null-member-id.edn
@@ -1,0 +1,2 @@
+{:up ["ALTER TABLE bookmarks ALTER COLUMN member_id SET NOT NULL;"]
+ :down ["ALTER TABLE bookmarks ALTER COLUMN member_id DROP NOT NULL;"]}

--- a/src/leaflike/bookmarks/core.clj
+++ b/src/leaflike/bookmarks/core.clj
@@ -12,13 +12,20 @@
   (let [username (:username request)]
     (first (user-db/get-member-auth-data username :id))))
 
+(defn- format-tags
+  "Convert :tags in a bookmark from a comma-separated string to a vector
+  of strings."
+  [bookmark]
+  (update bookmark :tags
+          #(if (string/blank? %)
+             nil
+             (string/split % #","))))
+
 (defn create
   [{:keys [params] :as request}]
-  (let [bookmark (-> (select-keys (walk/keywordize-keys params)
+  (let [bookmark (-> (select-keys params
                                   [:title :url :tags])
-                     (update-in [:tags] #(if (empty? %)
-                                           nil
-                                           (string/split % #","))))
+                     format-tags)
         user    (get-user request)]
     (if (valid-bookmark? bookmark)
       (let [bookmark (assoc bookmark

--- a/src/leaflike/bookmarks/core.clj
+++ b/src/leaflike/bookmarks/core.clj
@@ -1,11 +1,10 @@
 (ns leaflike.bookmarks.core
-  (:require [leaflike.bookmarks.validator :refer [valid-bookmark?
-                                                  id?]]
+  (:require [leaflike.bookmarks.validator :refer [valid-bookmark?]]
             [leaflike.bookmarks.db :as bm-db]
             [leaflike.user.db :as user-db]
             [leaflike.user.auth :refer [throw-unauthorized]]
             [leaflike.utils :as utils]
-            [clojure.walk :as walk]
+            [clojure.spec.alpha :as s]
             [clojure.string :as string]))
 
 (defn- get-user
@@ -26,7 +25,8 @@
                             :member_id (:id user)
                             :created_at (utils/get-timestamp))]
         (bm-db/create bookmark))
-      (throw (ex-info "Invalid params" {:bookmark bookmark})))))
+      (throw (ex-info "Invalid params" {:type :invalid-bookmark
+                                        :data bookmark})))))
 
 (defn list-all
   [request]
@@ -47,22 +47,25 @@
                               :count)]
         {:bookmarks bookmarks
          :num-pages (int (Math/ceil (/ num-bookmarks items-per-page)))})
-      (throw (ex-info "Invalid page number" {:page page})))))
+      (throw (ex-info "Invalid page number" {:type :invalid-page
+                                             :data page})))))
 
 (defn list-by-id
   [{:keys [route-params] :as request}]
   (let [id        (:id route-params)
         user      (get-user request)
         params    {:id id :member_id (:id user)}]
-    (if (id? id)
+    (if (s/valid? :leaflike.bookmarks.validator/id id)
       (bm-db/list-by-id params)
-      (throw (ex-info "Invalid id" {:id id})))))
+      (throw (ex-info "Invalid id" {:type :invalid-id
+                                    :data id})))))
 
 (defn delete
   [{:keys [route-params] :as request}]
   (let [id        (get-in request [:route-params :id])
         user      (get-user request)]
-    (if (id? id)
+    (if (s/valid? :leaflike.bookmarks.validator/id id)
       (bm-db/delete {:id id
                      :member_id (:id user)})
-      (throw (ex-info "Invalid id" {:id id})))))
+      (throw (ex-info "Invalid id" {:type :invalid-id
+                                    :id id})))))

--- a/src/leaflike/bookmarks/db.clj
+++ b/src/leaflike/bookmarks/db.clj
@@ -12,8 +12,7 @@
   ;; check if tags is nil?
   (if (nil? tags)
     bookmark
-    (assoc bookmark
-           :tags (types/array tags))))
+    (assoc bookmark)))
 
 (defn create
   [params]

--- a/src/leaflike/bookmarks/db.clj
+++ b/src/leaflike/bookmarks/db.clj
@@ -2,23 +2,20 @@
   (:require [clojure.java.jdbc :as jdbc]
             [honeysql.core     :as sql]
             [honeysql.helpers  :as helpers]
-            [honeysql.types    :as types]
+            [honeysql.types  :as types]
             [clojure.string    :as str]
             [leaflike.config   :refer [db-spec]]))
 
-(defn format-tags
-  [{:keys [tags] :as bookmark}]
-  ;; check if tag exists
-  ;; check if tags is nil?
-  (if (nil? tags)
-    bookmark
-    (assoc bookmark)))
+(defn- seq->pgarray
+  [s]
+  (when s (types/array s)))
 
 (defn create
-  [params]
-  (jdbc/execute! (db-spec) (-> (helpers/insert-into :bookmarks)
-                               (helpers/values [(format-tags params)])
-                               sql/format)))
+  [bookmark]
+  (let [bookmark (update bookmark :tags seq->pgarray)]
+    (jdbc/execute! (db-spec) (-> (helpers/insert-into :bookmarks)
+                                 (helpers/values [bookmark])
+                                 sql/format))))
 
 (defn list-all
   [{:keys [member_id]}]

--- a/src/leaflike/bookmarks/routes.clj
+++ b/src/leaflike/bookmarks/routes.clj
@@ -30,11 +30,13 @@
 
 (defn create-view
   [request]
-  (let [username (get-in request [:session :username])]
+  (let [username (get-in request [:session :username])
+        error-msg (get-in request [:flash :error-msg])]
     (-> (res/response (user-view "Add Bookmark"
                                  username
                                  (views/add-bookmark
-                                  anti-forgery/*anti-forgery-token*)))
+                                  anti-forgery/*anti-forgery-token*)
+                                 :error-msg error-msg))
         (assoc-in [:headers "Content-Type"] "text/html"))))
 
 (def bookmarks-routes

--- a/src/leaflike/bookmarks/views.clj
+++ b/src/leaflike/bookmarks/views.clj
@@ -2,6 +2,39 @@
   (:require [hiccup.form :as f]
             [clojure.string :as string]))
 
+(defn pagination
+  [num-pages current-page]
+  [:ul.pagination
+   ;; "Previous" button
+   (let [disabled-prev? (= current-page 1)
+         disabled-class (if disabled-prev?
+                          " disabled"
+                          "")]
+     [:li {:class (str "page-item" disabled-class)}
+      [:a {:class "page-link"
+           :href (str "/bookmarks/page/" (dec current-page))}
+       "Previous"]])
+   ;; List of pages
+   (for [page-num (range 1 (inc num-pages))]
+     (let [active? (= page-num current-page)
+           li-class "page-item"
+           li-class (if active?
+                      (str li-class " active")
+                      li-class)]
+       [:li {:class li-class}
+        [:a {:class "page-link"
+             :href (str "/bookmarks/page/" page-num)} page-num]]))
+
+   ;; "Next" button
+   (let [disabled-next? (= current-page num-pages)
+         disabled-class (if disabled-next?
+                          " disabled"
+                          "")]
+     [:li {:class (str "page-item" disabled-class)}
+      [:a {:class "page-link"
+           :href (str "/bookmarks/page/" (inc current-page))}
+       "Next"]])])
+
 (defn list-all
   [bookmarks num-pages current-page]
   [:div {:id "content"}
@@ -21,37 +54,8 @@
         [:td [:a {:href (:url bookmark)} (:title bookmark)]]
         [:td (:tags bookmark)]
         [:td (:created_at bookmark)]])]]
-
-   [:ul.pagination
-    ;; "Previous" button
-    (let [disabled-prev? (= current-page 1)
-          disabled-class (if disabled-prev?
-                           " disabled"
-                           "")]
-      [:li {:class (str "page-item" disabled-class)}
-       [:a {:class "page-link"
-            :href (str "/bookmarks/page/" (dec current-page))}
-        "Previous"]])
-    ;; List of pages
-    (for [page-num (range 1 (inc num-pages))]
-      (let [active? (= page-num current-page)
-            li-class "page-item"
-            li-class (if active?
-                       (str li-class " active")
-                       li-class)]
-        [:li {:class li-class}
-         [:a {:class "page-link"
-              :href (str "/bookmarks/page/" page-num)} page-num]]))
-
-    ;; "Next" button
-    (let [disabled-next? (= current-page num-pages)
-          disabled-class (if disabled-next?
-                           " disabled"
-                           "")]
-      [:li {:class (str "page-item" disabled-class)}
-       [:a {:class "page-link"
-            :href (str "/bookmarks/page/" (inc current-page))}
-        "Next"]])]])
+   (when (> num-pages 1)
+     (pagination num-pages current-page))])
 
 (defn add-bookmark
   [anti-forgery-token]

--- a/src/leaflike/bookmarks/views.clj
+++ b/src/leaflike/bookmarks/views.clj
@@ -7,8 +7,6 @@
   [:div {:id "content"}
    [:div {:class "row"}
     [:div {:class "col"}
-     [:h3 "Bookmarks"]]
-    [:div {:class "col"}
      [:a {:href "/bookmarks/add"}
       [:button {:class "btn btn-large btn-primary"} "Add bookmark"]]]]
    [:table {:class "table"}
@@ -35,14 +33,12 @@
             :href (str "/bookmarks/page/" (dec current-page))}
         "Previous"]])
     ;; List of pages
-    (for [i (range num-pages)]
-      (let [page-num (inc i)
-            active? (= page-num current-page)
-            li-classes ["page-item"]
-            li-classes (if active?
-                         (conj li-classes "active")
-                         li-classes)
-            li-class (string/join " " li-classes)]
+    (for [page-num (range 1 (inc num-pages))]
+      (let [active? (= page-num current-page)
+            li-class "page-item"
+            li-class (if active?
+                       (str li-class " active")
+                       li-class)]
         [:li {:class li-class}
          [:a {:class "page-link"
               :href (str "/bookmarks/page/" page-num)} page-num]]))
@@ -59,24 +55,22 @@
 
 (defn add-bookmark
   [anti-forgery-token]
-  [:div {:id "content"}
-   [:h3 "Add bookmark"]
-   [:div {:class "well"}
-    (f/form-to {:role "form"}
-               [:post "/bookmarks"]
-               [:div {:class "form-group"}
-                (f/label {:class "control-label"} "url" "URL")
-                (f/text-field {:class "form-control" :placeholder "URL"
-                               :required ""} "url")]
-               [:div {:class "form-group"}
-                (f/label {:class "control-label"} "title" "Title")
-                (f/text-field {:class "form-control" :placeholder "Title"
-                               :required ""} "title")]
-               [:div {:class "form-group"}
-                (f/label {:class "control-label"} "tags" "Tags")
-                (f/text-field {:class "form-control" :placeholder "Tags"} "tags")]
+  [:div {:class "well"}
+   (f/form-to {:role "form"}
+              [:post "/bookmarks"]
+              [:div {:class "form-group"}
+               (f/label {:class "control-label"} "url" "URL")
+               (f/text-field {:class "form-control" :placeholder "URL"
+                              :required ""} "url")]
+              [:div {:class "form-group"}
+               (f/label {:class "control-label"} "title" "Title")
+               (f/text-field {:class "form-control" :placeholder "Title"
+                              :required ""} "title")]
+              [:div {:class "form-group"}
+               (f/label {:class "control-label"} "tags" "Tags")
+               (f/text-field {:class "form-control" :placeholder "Tags"} "tags")]
 
-               [:div {:class "form-group"}
-                (f/submit-button {:class "btn btn-primary"} "Submit")]
+              [:div {:class "form-group"}
+               (f/submit-button {:class "btn btn-primary"} "Submit")]
 
-               (f/hidden-field {:value anti-forgery-token} "__anti-forgery-token"))]])
+              (f/hidden-field {:value anti-forgery-token} "__anti-forgery-token"))])

--- a/src/leaflike/layout.clj
+++ b/src/leaflike/layout.clj
@@ -9,8 +9,8 @@
           (include-css "//maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css")
           (include-css "/css/styles.css")
           [:body
-           [:header {:class "navbar navbar-dark bg-light"}
-            [:a.navbar-brand "Leaflike"]
+           [:header {:class "navbar navbar-light bg-light"}
+            [:a.navbar-brand {:href "/"} "Leaflike"]
             [:div {:class "navbar-nav-scroll"
                    :id "navbarSupportedContent"}
              (when username [:ul {:class "navbar-nav"}

--- a/src/leaflike/layout.clj
+++ b/src/leaflike/layout.clj
@@ -3,26 +3,33 @@
             [hiccup.element :refer [link-to]]))
 
 (defn application
-  [title & content]
+  [title content & {:keys [username error-msg]}]
   (html5 [:head
           [:title title]
           (include-css "//maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css")
           (include-css "/css/styles.css")
-          [:body content]]))
+          [:body
+           [:header {:class "navbar navbar-dark bg-light"}
+            [:a.navbar-brand "Leaflike"]
+            [:div {:class "navbar-nav-scroll"
+                   :id "navbarSupportedContent"}
+             (when username [:ul {:class "navbar-nav"}
+                             [:li {:class "nav-item"}
+                              (str "Logged in as " username)]
+                             [:li {:class "nav-item"}
+                              [:a {:href "/logout"} "Logout"]]])]]
+           [:div.container
+            [:div#content
+             [:h3 {:class "text-success"} title]
+             (when error-msg
+               [:div {:class "alert alert-danger"} error-msg])
+             content]]]]))
 
 (defn user-view
-  [title username & content]
-  (application title
-               [:header {:class "navbar navbar-dark bg-light"}
-                [:a.navbar-brand "Leaflike"]
-                [:div {:class "navbar-nav-scroll"
-                       :id "navbarSupportedContent"}
-                 [:ul {:class "navbar-nav"}
-                  [:li {:class "nav-item"}
-                   (str "Logged in as " username)]
-                  [:li {:class "nav-item"}
-                   [:a {:href "/logout"} "Logout"]]]]]
-               [:div {:class "container"} content]))
+  [title username content & {:keys [error-msg]}]
+  (application title content
+               :username username
+               :error-msg error-msg))
 
 (defn index
   []

--- a/src/leaflike/middlewares.clj
+++ b/src/leaflike/middlewares.clj
@@ -5,12 +5,22 @@
   (:import clojure.lang.ExceptionInfo))
 
 (defn handle-exception
+  "In case of an ExceptionInfo caused by bad input, adds a `flash`
+  message to be displayed to the user. If the `type` in the
+  ExceptionInfo is not known, return a HTTP 500 error."
   [e]
   (let [info (ex-data e)
-        type (:type info)]
-    (case type
-      :invalid-login (res/redirect "/login?error=1")
-      {:status 400
+        error-type (:type info)]
+    (case error-type
+      :invalid-login (assoc (res/redirect "/login")
+                            :flash {:error-msg "Invalid username/password"})
+      ;; TODO: Use spec/explain-* fns to figure out which keys were invalid.
+      :invalid-bookmark (assoc (res/redirect "/bookmarks/add")
+                               :flash {:error-msg "Invalid bookmark"})
+      ;; TODO: Use spec/explain-* fns to figure out what went wrong.
+      :invalid-signup (assoc (res/redirect "/signup")
+                             :flash {:error-msg "Invalid signup details"})
+      {:status 500
        :body (.getMessage e)})))
 
 (defn wrap-exception-handling

--- a/src/leaflike/routes.clj
+++ b/src/leaflike/routes.clj
@@ -14,9 +14,11 @@
 ;; Home page controller (ring handler)
 (defn home
   [request]
-  (let [homepage (layout/application "Leaflike" (layout/index))]
-    (-> (res/response homepage)
-        (assoc :headers {"Content-Type" "text/html"}))))
+  (if (get-in request [:session :username])
+    (res/redirect "/bookmarks")
+    (let [homepage (layout/application "Leaflike" (layout/index))]
+      (-> (res/response homepage)
+          (assoc :headers {"Content-Type" "text/html"})))))
 
 (def home-routes
   {""        {:get home}

--- a/src/leaflike/server.clj
+++ b/src/leaflike/server.clj
@@ -10,6 +10,8 @@
             [ring.middleware.json           :refer [wrap-json-params
                                                     wrap-json-response]]
             [ring.middleware.params         :refer [wrap-params]]
+            [ring.middleware.keyword-params :refer [wrap-keyword-params]]
+            [ring.middleware.flash :refer [wrap-flash]]
             [ring.middleware.session        :refer [wrap-session]]
             [ring.middleware.session.memory :as    mem]
             [ring.middleware.anti-forgery   :refer [wrap-anti-forgery]]
@@ -30,7 +32,9 @@
       (wrap-resource "public")
       (wrap-json-params {:keywords? true :bigdecimals? true})
       wrap-json-response
+      wrap-keyword-params
       wrap-params
+      wrap-flash
       (wrap-session {:store all-sessions})))
 
 (defonce server (atom nil))
@@ -42,13 +46,15 @@
                     (app) server-spec))
     (log/info (format "Server started at: %s:%d" (:ip server-spec) (:port server-spec)))))
 
-(defn stop! []
+(defn stop!
+  []
   (when-not (nil? @server)
     ;; graceful shutdown: wait 100ms for existing requests to be finished
     ;; :timeout is optional, when no timeout, stop immediately
     (@server :timeout 100)
     (reset! server nil)))
 
-(defn restart-server []
+(defn restart-server
+  []
   (stop!)
   (start!))

--- a/src/leaflike/user/auth.clj
+++ b/src/leaflike/user/auth.clj
@@ -38,7 +38,7 @@
   (let [verify-password (:verify-password member)
         user-password   (get-in member [:auth-data :password])
         username        (get-in member [:auth-data :username])
-        next-url        (get-in request [:query-params "next"] "/bookmarks")]
+        next-url        (get-in request [:params :next] "/bookmarks")]
     (if (hashers/check verify-password user-password)
       ;; login
       (-> (res/redirect next-url)
@@ -49,6 +49,6 @@
 
 (defn signup-auth
   [request username]
-  (let [next-url (get-in request [:query-params "next"] "/")]
+  (let [next-url (get-in request [:query-params :next] "/bookmarks")]
     (-> (res/redirect next-url)
         (assoc-in [:session :username] username))))

--- a/src/leaflike/user/core.clj
+++ b/src/leaflike/user/core.clj
@@ -21,9 +21,7 @@
   (let [login-details   (select-keys params [:username :password])
         member (validator/valid-login-details? login-details)]
     (if member
-      (let [data {:auth-data        (-> member
-                                        (assoc :username (str (:username member)))
-                                        (dissoc :email :created_at))
+      (let [data {:auth-data (select-keys member [:username :password :verify-password])
                   :verify-password  (:password login-details)}]
         (auth/login-auth request data))
       (throw (ex-info "Invalid login credentials" {:type :invalid-login

--- a/src/leaflike/user/core.clj
+++ b/src/leaflike/user/core.clj
@@ -2,25 +2,29 @@
   (:require [leaflike.user.db :as user-db]
             [leaflike.user.auth :as auth]
             [leaflike.user.validator :as validator]
-            [clojure.walk :as walk]))
+            [leaflike.user.views :as views]
+            [ring.util.response :as res]
+            [leaflike.layout :as layout]
+            [ring.middleware.anti-forgery :as anti-forgery]))
 
 (defn signup
   [{:keys [params] :as request}]
-  (let [user (walk/keywordize-keys params)]
+  (let [user (select-keys params [:email :username :password])]
     (if (validator/valid-signup-details? user)
       (do (user-db/create-user user)
           (auth/signup-auth request (:username user)))
-      (throw (ex-info "Invalid params" {:data params})))))
+      (throw (ex-info "Invalid params" {:type :invalid-signup
+                                        :data params})))))
 
 (defn login
   [{:keys [params] :as request}]
-  (let [body   (walk/keywordize-keys params)
-        member (validator/valid-login-details? body)]
+  (let [login-details   (select-keys params [:username :password])
+        member (validator/valid-login-details? login-details)]
     (if member
       (let [data {:auth-data        (-> member
                                         (assoc :username (str (:username member)))
                                         (dissoc :email :created_at))
-                  :verify-password  (:password body)}]
+                  :verify-password  (:password login-details)}]
         (auth/login-auth request data))
       (throw (ex-info "Invalid login credentials" {:type :invalid-login
                                                    :data params})))))
@@ -28,3 +32,24 @@
 (defn logout
   [request]  
   (auth/logout-auth request))
+
+(defn login-page
+  [{{:keys [next]} :params :as request}]
+  (let [error-msg (get-in request [:flash :error-msg])]
+    (-> (layout/application "Login"
+                            (views/login-form anti-forgery/*anti-forgery-token*
+                                              :next-url next)
+                            :error-msg error-msg)
+        res/response
+        (assoc :headers {"Content-Type" "text/html"}
+               :status 200))))
+
+(defn signup-page
+  [request]
+  (let [error-msg (get-in request [:flash :error-msg])]
+    (-> (res/response (layout/application 
+                       "Signup"
+                       (views/signup-form anti-forgery/*anti-forgery-token*)
+                       :error-msg error-msg))
+        (assoc :headers {"Content-Type" "text/html"}
+               :status 200))))

--- a/src/leaflike/user/routes.clj
+++ b/src/leaflike/user/routes.clj
@@ -1,51 +1,12 @@
 (ns leaflike.user.routes
   (:require [leaflike.user.core :as user-core]
-            [leaflike.user.views :as views]
-            [leaflike.middlewares :refer [with-auth-middlewares]]
-            [ring.middleware.anti-forgery :as anti-forgery]
-            [ring.util.response :as res]
-            [leaflike.layout :as layout]))
-
-(defn signup
-  [request]
-  (user-core/signup request))
-
-(defn login
-  [request]
-  ;; authenticate
-  (user-core/login request))
-
-(defn logout
-  [request]
-  ;; logout
-  (user-core/logout request))
-
-(let [error-code->msg {1 "Invalid username/password"}]
-  (defn login-page
-    [{{:strs [next error]} :query-params :as request}]
-    (let [error-msg (when error
-                      (error-code->msg (Integer/parseInt error)))]
-      (-> (res/response (layout/application
-                         "Login"
-                         (views/login-form anti-forgery/*anti-forgery-token*
-                                           :next-url next
-                                           :error-msg error-msg)))
-          (assoc :headers {"Content-Type" "text/html"})
-          (assoc :status 200)))))
-
-(defn signup-page
-  [request]
-  (-> (res/response (layout/application 
-                     "Signup"
-                     (views/signup-form anti-forgery/*anti-forgery-token*)))
-      (assoc :headers {"Content-Type" "text/html"})
-      (assoc :status 200)))
+            [leaflike.middlewares :refer [with-auth-middlewares]]))
 
 (def user-routes
   {;; existing user
-   "login"        {:post login
-                   :get  login-page}
-   "logout"       (with-auth-middlewares  {:get logout})
+   "login"        {:post user-core/login
+                   :get  user-core/login-page}
+   "logout"       (with-auth-middlewares  {:get user-core/logout})
    ;; new user
-   "signup"       {:post signup
-                   :get  signup-page}})
+   "signup"       {:post user-core/signup
+                   :get  user-core/signup-page}})

--- a/src/leaflike/user/views.clj
+++ b/src/leaflike/user/views.clj
@@ -7,38 +7,9 @@
   (let [login-url (if (empty? next-url)
                     "/login"
                     (str "/login?next=" next-url))]
-    [:div {:class "container"}
-     [:div {:id "content"}
-      [:h3 {:class "text-success"} "Login"]
-      (when error-msg
-        [:div {:class "alert alert-danger"} error-msg])
-      [:div {:class "well well-width"}
-       (f/form-to {:role "form"}
-                  [:post login-url]
-                  [:div {:class "form-group"}
-                   (f/label {:class "control-label"} "username" "Username")
-                   (f/text-field {:class "form-control" :placeholder "Username"
-                                  :required ""} "username")]
-                  [:div {:class "form-group"}
-                   (f/label {:class "control-label"} "password" "Password")
-                   (f/password-field {:class "form-control" :placeholder "Password"
-                                      :required ""} "password")]
-                  [:div {:class "form-group"}
-                   (f/submit-button {:class "btn btn-primary"} "Login")]
-                  (f/hidden-field {:value anti-forgery-token} "__anti-forgery-token"))]]]))
-
-(defn signup-form
-  [anti-forgery-token]
-  [:div {:class "container"}
-   [:div {:id "content"}
-    [:h3 {:class "text-success"} "Signup"]
     [:div {:class "well well-width"}
      (f/form-to {:role "form"}
-                [:post "/signup"]
-                [:div {:class "form-group"}
-                 (f/label {:class "control-label"} "email" "Email")
-                 (f/email-field {:class "form-control" :placeholder "Email"
-                                 :required ""} "email")]
+                [:post login-url]
                 [:div {:class "form-group"}
                  (f/label {:class "control-label"} "username" "Username")
                  (f/text-field {:class "form-control" :placeholder "Username"
@@ -48,5 +19,26 @@
                  (f/password-field {:class "form-control" :placeholder "Password"
                                     :required ""} "password")]
                 [:div {:class "form-group"}
-                 (f/submit-button {:class "btn btn-primary"} "Signup")]
-                (f/hidden-field {:value anti-forgery-token} "__anti-forgery-token"))]]])
+                 (f/submit-button {:class "btn btn-primary"} "Login")]
+                (f/hidden-field {:value anti-forgery-token} "__anti-forgery-token"))]))
+
+(defn signup-form
+  [anti-forgery-token]
+  [:div {:class "well well-width"}
+   (f/form-to {:role "form"}
+              [:post "/signup"]
+              [:div {:class "form-group"}
+               (f/label {:class "control-label"} "email" "Email")
+               (f/email-field {:class "form-control" :placeholder "Email"
+                               :required ""} "email")]
+              [:div {:class "form-group"}
+               (f/label {:class "control-label"} "username" "Username")
+               (f/text-field {:class "form-control" :placeholder "Username"
+                              :required ""} "username")]
+              [:div {:class "form-group"}
+               (f/label {:class "control-label"} "password" "Password")
+               (f/password-field {:class "form-control" :placeholder "Password"
+                                  :required ""} "password")]
+              [:div {:class "form-group"}
+               (f/submit-button {:class "btn btn-primary"} "Signup")]
+              (f/hidden-field {:value anti-forgery-token} "__anti-forgery-token"))])


### PR DESCRIPTION
- Make `member_id` non-nullable
- Use `wrap-keyword-params`
- Use `ring.middleware.flash` to show errors to the user.
- If user is logged in, going to `/`, '/login', or '/signup' redirects the user to the bookmarks page.