### PR TITLE
Set `server_name` in nginx.conf

### DIFF
--- a/scripts/nginx.conf
+++ b/scripts/nginx.conf
@@ -38,7 +38,7 @@ listen {
 	# Add index.php to the list if you are using PHP
 	index index.html index.htm index.nginx-debian.html;
 
-	server_name _;
+	server_name leaflike.nilenso.com;
 
 	location / {
 		proxy_pass http://127.0.0.1:8000;


### PR DESCRIPTION
Required for setting up HTTPs