### PR TITLE
Share bookmarks with the users of leaflike

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ pom.xml.asc
 *#
 logfile
 /config/config.edn.prod
+/.idea

--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,7 @@
                  [bidi "2.1.2"]
                  [ring/ring-json "0.4.0"]
                  [commons-validator "1.5.1"]
-                 [honeysql "0.9.1"]
+                 [honeysql "0.9.4"]
                  [buddy "2.0.0"]
                  [org.clojure/algo.generic "0.1.2"]
                  [hiccup "2.0.0-alpha1"]

--- a/resources/migrations/011-add-collaborators.edn
+++ b/resources/migrations/011-add-collaborators.edn
@@ -1,9 +1,16 @@
-{:up   ["ALTER TABLE bookmarks ADD COLUMN owner integer not null DEFAULT '-1';
-        UPDATE bookmarks SET owner = user_id;
-        CREATE TABLE bookmark_user (
+{:up   ["CREATE TABLE bookmark_user (
                                  user_id integer references users(id),
                                  bookmark_id integer references bookmarks(id),
-                                 PRIMARY KEY (user_id, bookmark_id));"]
+                                 PRIMARY KEY (user_id, bookmark_id));
+         INSERT INTO bookmark_user(user_id, bookmark_id) (SELECT user_id, id FROM bookmarks);
+         ALTER TABLE bookmarks DROP CONSTRAINT bookmarks_member_id_fkey;
+         ALTER TABLE bookmarks RENAME COLUMN user_id to created_by;"]
 
- :down ["ALTER TABLE bookmarks DROP COLUMN owner;
+ :down ["ALTER TABLE bookmarks RENAME COLUMN created_by to user_id;
+
+        ALTER TABLE bookmarks
+        ADD CONSTRAINT bookmarks_member_id_fkey
+        FOREIGN KEY (user_id)
+        REFERENCES users (id);
+
         DROP TABLE bookmark_user;"]}

--- a/resources/migrations/011-add-collaborators.edn
+++ b/resources/migrations/011-add-collaborators.edn
@@ -4,5 +4,6 @@
                                  user_id integer references users(id),
                                  bookmark_id integer references bookmarks(id),
                                  PRIMARY KEY (user_id, bookmark_id));"]
+
  :down ["ALTER TABLE bookmarks DROP COLUMN owner;
         DROP TABLE bookmark_user;"]}

--- a/resources/migrations/011-add-collaborators.edn
+++ b/resources/migrations/011-add-collaborators.edn
@@ -1,0 +1,8 @@
+{:up   ["ALTER TABLE bookmarks ADD COLUMN owner integer not null DEFAULT '-1';
+        UPDATE bookmarks SET owner = user_id;
+        CREATE TABLE bookmark_user (
+                                 user_id integer references users(id),
+                                 bookmark_id integer references bookmarks(id),
+                                 PRIMARY KEY (user_id, bookmark_id));"]
+ :down ["ALTER TABLE bookmarks DROP COLUMN owner;
+        DROP TABLE bookmark_user;"]}

--- a/src/leaflike/bookmarks.clj
+++ b/src/leaflike/bookmarks.clj
@@ -76,12 +76,12 @@
   [{:keys [params] :as request}]
   (let [username (get-in request [:session :username])
         user-id (:id (user-db/get-user-if-exists username))
-        created_by (:created_by (into {} (-> (Integer/parseInt (:id params))
+        created-by (:created_by (into {} (-> (Integer/parseInt (:id params))
                                              (bm-db/get-creator))))]
-    (if (= user-id created_by)
+    (if (= user-id created-by)
       (edit request)
       (assoc (res/redirect (str "/bookmarks/edit/" (:id params)))
-        :flash {:error-msg (str "Only " (:username (into {} (user-db/get-username-by-user-id created_by)))
+        :flash {:error-msg (str "Only " (:username (into {} (user-db/get-username-by-user-id created-by)))
                                 " can edit this bookmark")}))))
 
 (def items-per-page 10)

--- a/src/leaflike/bookmarks.clj
+++ b/src/leaflike/bookmarks.clj
@@ -231,9 +231,7 @@
                     "The bookmark you're trying to edit does not exist.")
         all-tags (map :name (tags-db/fetch-tags {:user-id (:id user)}))
         collaborator-ids (map :user_id (bm-db/get-collaborator-ids bookmark-id))]
-    (-> (res/response (layout/user-view "Edit Bookmark"
-                                        username
-                                        (views/bookmark-form
+    (-> (res/response (layout/user-view "Edit Bookmark" username (views/bookmark-form
                                           anti-forgery/*anti-forgery-token*
                                           "/bookmarks/edit"
                                           (assoc bookmark

--- a/src/leaflike/bookmarks.clj
+++ b/src/leaflike/bookmarks.clj
@@ -117,7 +117,7 @@
         unparsed-id (:id params)]
     (if (s/valid? :leaflike.bookmarks.spec/id unparsed-id)
       (let [id (Integer/parseInt unparsed-id)]
-        (if (= (:created_by (reduce conj {} (bm-db/get-created-by id))) (:id user))
+        (if (= ({:keys [:created_by]} (bm-db/get-created-by id)) (:id user))
           (do
             (bm-db/remove-all-tags id)
             (bm-db/remove-all-bookmark-users id)
@@ -230,7 +230,7 @@
                     (get-in request [:flash :error-msg])
                     "The bookmark you're trying to edit does not exist.")
         all-tags (map :name (tags-db/fetch-tags {:user-id (:id user)}))
-        collaborators-id (map :user_id (bm-db/get-collaborator-ids bookmark-id))]
+        collaborator-ids (map :user_id (bm-db/get-collaborator-ids bookmark-id))]
     (-> (res/response (layout/user-view "Edit Bookmark"
                                         username
                                         (views/bookmark-form
@@ -240,8 +240,8 @@
                                             :all-tags all-tags
                                             :collaborators
                                             (map :username
-                                                 (if (not-empty collaborators-id)
-                                                   (bm-db/get-collaborators-from-ids collaborators-id)))))
+                                                 (if (not-empty collaborator-ids)
+                                                   (bm-db/get-collaborators-from-ids collaborator-ids)))))
                                         :error-msg error-msg))
         (assoc-in [:headers "Content-Type"] "text/html"))))
 

--- a/src/leaflike/bookmarks.clj
+++ b/src/leaflike/bookmarks.clj
@@ -77,7 +77,7 @@
   (let [username (get-in request [:session :username])
         user-id (:id (user-db/get-user-if-exists username))
         created_by (:created_by (into {} (-> (Integer/parseInt (:id params))
-                                             (bm-db/get-created-by))))]
+                                             (bm-db/get-creator))))]
     (if (= user-id created_by)
       (edit request)
       (assoc (res/redirect (str "/bookmarks/edit/" (:id params)))
@@ -117,7 +117,7 @@
         unparsed-id (:id params)]
     (if (s/valid? :leaflike.bookmarks.spec/id unparsed-id)
       (let [id (Integer/parseInt unparsed-id)]
-        (if (= (:created_by (reduce conj {} (bm-db/get-created-by id))) (:id user))
+        (if (= (:created_by (bm-db/get-creator id)) (:id user))
           (do
             (bm-db/remove-all-tags id)
             (bm-db/remove-all-bookmark-users id)
@@ -232,14 +232,14 @@
         all-tags (map :name (tags-db/fetch-tags {:user-id (:id user)}))
         collaborator-ids (map :user_id (bm-db/get-collaborator-ids bookmark-id))]
     (-> (res/response (layout/user-view "Edit Bookmark" username (views/bookmark-form
-                                          anti-forgery/*anti-forgery-token*
-                                          "/bookmarks/edit"
-                                          (assoc bookmark
-                                            :all-tags all-tags
-                                            :collaborators
-                                            (map :username
-                                                 (if (not-empty collaborator-ids)
-                                                   (bm-db/get-collaborators-from-ids collaborator-ids)))))
+                                                                   anti-forgery/*anti-forgery-token*
+                                                                   "/bookmarks/edit"
+                                                                   (assoc bookmark
+                                                                     :all-tags all-tags
+                                                                     :collaborators
+                                                                     (map :username
+                                                                          (if (not-empty collaborator-ids)
+                                                                            (bm-db/get-collaborators-from-ids collaborator-ids)))))
                                         :error-msg error-msg))
         (assoc-in [:headers "Content-Type"] "text/html"))))
 

--- a/src/leaflike/bookmarks.clj
+++ b/src/leaflike/bookmarks.clj
@@ -101,7 +101,7 @@
      :num-pages (max 1
                      (int (Math/ceil (/ num-bookmarks items-per-page))))}))
 
-(defn list-by-id
+(defn list-by-creator-id
   [{:keys [route-params] :as request}]
   (let [id (:id route-params)
         user (hutils/get-user request)

--- a/src/leaflike/bookmarks.clj
+++ b/src/leaflike/bookmarks.clj
@@ -228,15 +228,16 @@
                     (get-in request [:flash :error-msg])
                     "The bookmark you're trying to edit does not exist.")
         all-tags (map :name (tags-db/fetch-tags {:user-id (:id user)}))
-        collaborators (map :username (bm-db/get-collaborators-for-bookmark bookmark-id))]
+        collaborators-id (map :user_id (bm-db/get-collaborator-ids bookmark-id))]
     (-> (res/response (layout/user-view "Edit Bookmark"
                                         username
-                                        (views/bookmark-form
-                                          anti-forgery/*anti-forgery-token*
-                                          "/bookmarks/edit"
-                                          (assoc bookmark
-                                            :all-tags all-tags
-                                            :collaborators collaborators))
+                                        (views/bookmark-form anti-forgery/*anti-forgery-token*
+                                                             "/bookmarks/edit"
+                                                             (assoc bookmark
+                                                               :all-tags all-tags
+                                                               :collaborators
+                                                               (map :username (if (not-empty collaborators-id)
+                                                                                (bm-db/get-collaborators-from-ids collaborators-id)))))
                                         :error-msg error-msg))
         (assoc-in [:headers "Content-Type"] "text/html"))))
 

--- a/src/leaflike/bookmarks.clj
+++ b/src/leaflike/bookmarks.clj
@@ -117,7 +117,7 @@
         unparsed-id (:id params)]
     (if (s/valid? :leaflike.bookmarks.spec/id unparsed-id)
       (let [id (Integer/parseInt unparsed-id)]
-        (if (= ({:keys [:created_by]} (bm-db/get-created-by id)) (:id user))
+        (if (= (:created_by (reduce conj {} (bm-db/get-created-by id))) (:id user))
           (do
             (bm-db/remove-all-tags id)
             (bm-db/remove-all-bookmark-users id)

--- a/src/leaflike/bookmarks.clj
+++ b/src/leaflike/bookmarks.clj
@@ -117,18 +117,24 @@
         unparsed-id (:id params)]
     (if (s/valid? :leaflike.bookmarks.spec/id unparsed-id)
       (let [id (Integer/parseInt unparsed-id)]
-        (if (= (:created_by (bm-db/get-creator id)) (:id user))
-          (do
-            (bm-db/remove-all-tags id)
-            (bm-db/remove-all-bookmark-users id)
-            (bm-db/delete id)
-            (assoc (res/redirect "/bookmarks")
-              :flash {:success-msg "Successfully deleted bookmark"}))
-          (do
-            (bm-db/remove {:bookmark-id id
-                           :user-id     (:id user)})
-            (assoc (res/redirect "/bookmarks")
-              :flash {:success-msg "Successfully removed bookmark"}))))
+        (bm-db/remove-all-tags id)
+        (bm-db/remove-all-bookmark-users id)
+        (bm-db/delete id)
+        (assoc (res/redirect "/bookmarks")
+          :flash {:success-msg "Successfully deleted bookmark"}))
+      (assoc (res/redirect "/bookmarks")
+        :flash {:error-msg "Invalid bookmark id"}))))
+
+(defn remove
+  [{:keys [params] :as request}]
+  (let [user (hutils/get-user request)
+        unparsed-id (:id params)]
+    (if (s/valid? :leaflike.bookmarks.spec/id unparsed-id)
+      (let [id (Integer/parseInt unparsed-id)]
+        (bm-db/remove {:bookmark-id id
+                       :user-id     (:id user)})
+        (assoc (res/redirect "/bookmarks")
+          :flash {:success-msg "Successfully removed bookmark"}))
       (assoc (res/redirect "/bookmarks")
         :flash {:error-msg "Invalid bookmark id"}))))
 

--- a/src/leaflike/bookmarks.clj
+++ b/src/leaflike/bookmarks.clj
@@ -230,22 +230,20 @@
   [{:keys [params] :as request}]
   (let [username (get-in request [:session :username])
         user (hutils/get-user request)
+        user-id (:id user)
         bookmark-id (Integer/parseInt (:bookmark-id params))
         bookmark (bm-db/fetch-bookmark bookmark-id)
         error-msg (if bookmark
                     (get-in request [:flash :error-msg])
                     "The bookmark you're trying to edit does not exist.")
-        all-tags (map :name (tags-db/fetch-tags {:user-id (:id user)}))
-        collaborator-ids (map :user_id (bm-db/get-collaborator-ids bookmark-id))]
+        all-tags (map :name (tags-db/fetch-tags {:user-id user-id}))
+        collaborators (map :username (bm-db/get-collaborators bookmark-id))]
     (-> (res/response (layout/user-view "Edit Bookmark" username (views/bookmark-form
                                                                    anti-forgery/*anti-forgery-token*
                                                                    "/bookmarks/edit"
                                                                    (assoc bookmark
                                                                      :all-tags all-tags
-                                                                     :collaborators
-                                                                     (map :username
-                                                                          (if (not-empty collaborator-ids)
-                                                                            (bm-db/get-collaborators-from-ids collaborator-ids)))))
+                                                                     :collaborators collaborators))
                                         :error-msg error-msg))
         (assoc-in [:headers "Content-Type"] "text/html"))))
 

--- a/src/leaflike/bookmarks.clj
+++ b/src/leaflike/bookmarks.clj
@@ -32,8 +32,11 @@
                               :created_at (utils/get-timestamp)))
           tags (parse-input ::bm-spec/tags (:tags params))
           bookmark-id (bm-db/create bookmark)
-          next-url (:next params "/bookmarks")]
-      (bm-db/user-bookmark (:id user) :bookmark-id)
+          next-url (:next params "/bookmarks")
+          collaborators (parse-input ::bm-spec/collaborators (:collaborators params))
+          collaborators-id (utils/vals-from-list-of-maps (user-db/get-user-ids-by-username collaborators))]
+      (when (not-empty collaborators-id)
+        (bm-db/bookmark-user bookmark-id collaborators-id))
       (when (not-empty tags)
         (tags-db/create tags)
         (bm-db/tag-bookmark bookmark-id tags))
@@ -54,6 +57,8 @@
           collaborators-id (utils/vals-from-list-of-maps (user-db/get-user-ids-by-username collaborators))]
       (bm-db/update-bookmark bookmark-id (:id user) updated-keys)
       (bm-db/remove-all-tags bookmark-id)
+      (when (not-empty collaborators-id)
+        (bm-db/bookmark-user bookmark-id collaborators-id))
       (when (not-empty tags)
         (tags-db/create tags)
         (bm-db/tag-bookmark bookmark-id tags))

--- a/src/leaflike/bookmarks.clj
+++ b/src/leaflike/bookmarks.clj
@@ -115,7 +115,7 @@
             (assoc (res/redirect "/bookmarks")
               :flash {:success-msg "Successfully deleted bookmark"}))
           (do
-            (bm-db/remove {:id      id
+            (bm-db/remove {:bookmark-id      id
                            :user-id (:id user)})
             (assoc (res/redirect "/bookmarks")
               :flash {:success-msg "Successfully removed bookmark"}))))

--- a/src/leaflike/bookmarks/db.clj
+++ b/src/leaflike/bookmarks/db.clj
@@ -216,6 +216,7 @@
   (jdbc/execute! (db-spec) (-> (helpers/delete-from :bookmark_user)
                                (helpers/where [:in :bookmark_id [bookmark-id]])
                                sql/format)))
+
 (defn get-collaborators-from-ids
   [collaborators]
   (jdbc/query (db-spec)

--- a/src/leaflike/bookmarks/db.clj
+++ b/src/leaflike/bookmarks/db.clj
@@ -213,6 +213,13 @@
   (jdbc/execute! (db-spec) (-> (helpers/delete-from :bookmark_user)
                                (helpers/where [:in :bookmark_id [bookmark-id]])
                                sql/format)))
+(defn get-collaborators-from-ids
+  [collaborators]
+  (jdbc/query (db-spec)
+              (-> (helpers/select :username)
+                  (helpers/from :users)
+                  (helpers/where [:in :id collaborators])
+                  sql/format)))
 
 (defn get-collaborator-ids [bookmark-id]
   (jdbc/query (db-spec)
@@ -221,12 +228,3 @@
                   (helpers/where [:and [:in :bookmark_id [bookmark-id]]
                                   [:not= :user_id (:created_by (reduce conj {} (get-created-by bookmark-id)))]])
                   sql/format)))
-
-(defn get-collaborators-for-bookmark
-  [bookmark-id]
-  (jdbc/query (db-spec)
-              (-> (helpers/select :username)
-                  (helpers/from :users)
-                  (helpers/where [:in :id (into [] (map :user_id (get-collaborator-ids bookmark-id)))])
-                  sql/format)))
-

--- a/src/leaflike/bookmarks/db.clj
+++ b/src/leaflike/bookmarks/db.clj
@@ -199,11 +199,11 @@
 
 (defn get-creator [bookmark-id]
   (-> (jdbc/query (db-spec)
-              (-> (helpers/select :created_by)
-                  (helpers/from :bookmarks)
-                  (helpers/where [:= :id bookmark-id])
-                  sql/format))
-  first))
+                  (-> (helpers/select :created_by)
+                      (helpers/from :bookmarks)
+                      (helpers/where [:= :id bookmark-id])
+                      sql/format))
+      first))
 
 (defn remove-all-bookmark-collaborators
   [bookmark-id]

--- a/src/leaflike/bookmarks/db.clj
+++ b/src/leaflike/bookmarks/db.clj
@@ -167,7 +167,8 @@
                   (helpers/left-join [:users :u] [:= :user-bookmarks.user_id :u.id])
                   sql/format))))
 
-(defn fetch-bookmarks-for-user [user-id]
+(defn fetch-bookmarks-for-user
+  [user-id]
   (jdbc/query (db-spec)
               (->
                 (helpers/select :*)
@@ -212,6 +213,7 @@
                      sql/format)))
 
 (defn remove-all-bookmark-users
+  "Removes the collaborators and the owner."
   [bookmark-id]
   (jdbc/execute! (db-spec) (-> (helpers/delete-from :bookmark_user)
                                (helpers/where [:in :bookmark_id [bookmark-id]])
@@ -225,7 +227,8 @@
                   (helpers/where [:in :id collaborators])
                   sql/format)))
 
-(defn get-collaborator-ids [bookmark-id]
+(defn get-collaborator-ids
+  [bookmark-id]
   (jdbc/query (db-spec)
               (-> (helpers/select :user_id)
                   (helpers/from :bookmark_user)

--- a/src/leaflike/bookmarks/db.clj
+++ b/src/leaflike/bookmarks/db.clj
@@ -208,7 +208,7 @@
   (jdbc/execute! (db-spec)
                  (-> (helpers/delete-from :bookmark_user)
                      (helpers/where [:and [:in :bookmark_id [bookmark-id]]
-                                     [:not= :user_id ({:keys [:created_by]} (get-created-by bookmark-id))]])
+                                     [:not= :user_id (:created_by (reduce conj {} (get-created-by bookmark-id)))]])
                      sql/format)))
 
 (defn remove-all-bookmark-users
@@ -230,5 +230,5 @@
               (-> (helpers/select :user_id)
                   (helpers/from :bookmark_user)
                   (helpers/where [:and [:in :bookmark_id [bookmark-id]]
-                                  [:not= :user_id ({:keys [:created_by]} (get-created-by bookmark-id))]])
+                                  [:not= :user_id (:created_by (reduce conj {} (get-created-by bookmark-id)))]])
                   sql/format)))

--- a/src/leaflike/bookmarks/db.clj
+++ b/src/leaflike/bookmarks/db.clj
@@ -210,10 +210,9 @@
 
 (defn remove-all-bookmark-users
   [bookmark-id]
-  (jdbc/execute! (db-spec)
-                 (utils/debug (-> (helpers/select :bookmark_user)
-                                  (helpers/where [:in :bookmark_id [bookmark-id]])
-                                  sql/format))))
+  (jdbc/execute! (db-spec) (-> (helpers/delete-from :bookmark_user)
+                               (helpers/where [:in :bookmark_id [bookmark-id]])
+                               sql/format)))
 
 (defn get-collaborator-ids [bookmark-id]
   (jdbc/query (db-spec)
@@ -225,9 +224,9 @@
 
 (defn get-collaborators-for-bookmark
   [bookmark-id]
-  (utils/debug (jdbc/query (db-spec)
-                           (-> (helpers/select :username)
-                               (helpers/from :users)
-                               (helpers/where [:in :id (into [] (map :user_id (get-collaborator-ids bookmark-id)))])
-                               sql/format))))
+  (jdbc/query (db-spec)
+              (-> (helpers/select :username)
+                  (helpers/from :users)
+                  (helpers/where [:in :id (into [] (map :user_id (get-collaborator-ids bookmark-id)))])
+                  sql/format)))
 

--- a/src/leaflike/bookmarks/db.clj
+++ b/src/leaflike/bookmarks/db.clj
@@ -49,12 +49,18 @@
                      sql/format)))
 
 
-(defn user-bookmark
-  [user-id bookmark-id]
+(defn bookmark-user
+  [bookmark-id user-ids]
   (jdbc/execute! (db-spec)
                  (-> (helpers/insert-into :bookmark_user)
-                     (helpers/columns :user_id :bookmark_id)
-                     (helpers/values [user-id bookmark-id])
+                     (helpers/columns :bookmark_id :user_id)
+                     (helpers/query-values
+                       (-> (helpers/select :bookmark_id :user_id)
+                           (helpers/from
+                             [(helpers/select [bookmark-id :bookmark_id]) :_bookmark_id]
+                             [(-> (helpers/select [:id :user_id])
+                                  (helpers/from :users)
+                                  (helpers/where [:in :id user-ids])) :_id])))
                      sql/format)))
 
 (defn remove-all-tags

--- a/src/leaflike/bookmarks/db.clj
+++ b/src/leaflike/bookmarks/db.clj
@@ -208,7 +208,7 @@
   (jdbc/execute! (db-spec)
                  (-> (helpers/delete-from :bookmark_user)
                      (helpers/where [:and [:in :bookmark_id [bookmark-id]]
-                                     [:not= :user_id (:created_by (reduce conj {} (get-created-by bookmark-id)))]])
+                                     [:not= :user_id ({:keys [:created_by]} (get-created-by bookmark-id))]])
                      sql/format)))
 
 (defn remove-all-bookmark-users
@@ -230,5 +230,5 @@
               (-> (helpers/select :user_id)
                   (helpers/from :bookmark_user)
                   (helpers/where [:and [:in :bookmark_id [bookmark-id]]
-                                  [:not= :user_id (:created_by (reduce conj {} (get-created-by bookmark-id)))]])
+                                  [:not= :user_id ({:keys [:created_by]} (get-created-by bookmark-id))]])
                   sql/format)))

--- a/src/leaflike/bookmarks/db.clj
+++ b/src/leaflike/bookmarks/db.clj
@@ -116,7 +116,7 @@
 (defn all-bookmarks-map
   [user-id]
   (-> (helpers/select :b.id :b.title :b.url :b.created_at
-                      :b.user_id
+                      :b.user_id :b.created_by
                       [(sql/call :array_remove :%array_agg.t.name :null) :tags])
       (helpers/from [(join-bookmarks-with-bookmark_user user-id) :b])
       (helpers/left-join [:bookmark_tag :bt] [:= :b.id :bt.bookmark_id]
@@ -163,7 +163,8 @@
                   (helpers/where where-clause)
                   (helpers/limit limit)
                   (helpers/offset offset)
-                  (helpers/order-by [:created_at :desc])
+                  (helpers/order-by [:user-bookmarks.created_at :user-bookmarks.desc])
+                  (helpers/left-join [:users :u] [:= :user-bookmarks.user_id :u.id])
                   sql/format))))
 
 (defn fetch-bookmarks-for-user [user-id]

--- a/src/leaflike/bookmarks/db.clj
+++ b/src/leaflike/bookmarks/db.clj
@@ -169,10 +169,12 @@
 
 (defn fetch-bookmarks-for-user [user-id]
   (jdbc/query (db-spec)
-              (-> (helpers/select :*)
-                  (helpers/from :bookmarks)
-                  (helpers/where [:= :created_by user-id])
-                  sql/format)))
+              (->
+                (helpers/select :*)
+                ;; sub-query gets all of user's bookmarks joined with tags
+                (helpers/from [(all-bookmarks-map user-id) :user-bookmarks])
+                (helpers/left-join [:users :u] [:= :user-bookmarks.user_id :u.id])
+                sql/format)))
 
 (defn list-by-id
   [{:keys [id user-id]}]

--- a/src/leaflike/bookmarks/db.clj
+++ b/src/leaflike/bookmarks/db.clj
@@ -197,19 +197,20 @@
                                                [:= :user_id user-id]])
                                sql/format)))
 
-(defn get-created-by [bookmark-id]
-  (jdbc/query (db-spec)
+(defn get-creator [bookmark-id]
+  (-> (jdbc/query (db-spec)
               (-> (helpers/select :created_by)
                   (helpers/from :bookmarks)
                   (helpers/where [:= :id bookmark-id])
-                  sql/format)))
+                  sql/format))
+  first))
 
 (defn remove-all-bookmark-collaborators
   [bookmark-id]
   (jdbc/execute! (db-spec)
                  (-> (helpers/delete-from :bookmark_user)
                      (helpers/where [:and [:in :bookmark_id [bookmark-id]]
-                                     [:not= :user_id (:created_by (reduce conj {} (get-created-by bookmark-id)))]])
+                                     [:not= :user_id (:created_by (get-creator bookmark-id))]])
                      sql/format)))
 
 (defn remove-all-bookmark-users
@@ -233,5 +234,5 @@
               (-> (helpers/select :user_id)
                   (helpers/from :bookmark_user)
                   (helpers/where [:and [:in :bookmark_id [bookmark-id]]
-                                  [:not= :user_id (:created_by (reduce conj {} (get-created-by bookmark-id)))]])
+                                  [:not= :user_id (:created_by (get-creator bookmark-id))]])
                   sql/format)))

--- a/src/leaflike/bookmarks/db.clj
+++ b/src/leaflike/bookmarks/db.clj
@@ -195,7 +195,7 @@
 
 (defn insert-into-bookmark-user [bookmark-user]
   (jdbc/execute! (db-spec)
-                 (-> (pg-helpers/insert-into-as :bookmark-user :bu)
+                 (-> (helpers/insert-into :bookmark-user)
                      (helpers/values [bookmark-user])
                      sql/format)))
 

--- a/src/leaflike/bookmarks/db.clj
+++ b/src/leaflike/bookmarks/db.clj
@@ -171,7 +171,7 @@
   (jdbc/query (db-spec)
               (-> (helpers/select :*)
                   (helpers/from :bookmarks)
-                  (helpers/where [:= :user_id user-id])
+                  (helpers/where [:= :created_by user-id])
                   sql/format)))
 
 (defn list-by-id
@@ -179,7 +179,7 @@
   (jdbc/query (db-spec) (-> (helpers/select :*)
                             (helpers/from :bookmarks)
                             (helpers/where [:and [:= :id (Integer/parseInt id)]
-                                            [:= :user_id user-id]])
+                                            [:= :created_by user-id]])
                             sql/format)))
 (defn delete
   [bookmark-id]

--- a/src/leaflike/bookmarks/spec.clj
+++ b/src/leaflike/bookmarks/spec.clj
@@ -34,6 +34,11 @@
                :string string?
                :coll-of-strings (s/coll-of string?)))
 
+(s/def ::collaborators (s/or
+                :nil nil?
+                :string string?
+                :coll-of-strings (s/coll-of string?)))
+
 (s/def ::bookmark (s/keys :req-un [::title ::url]
                           :opt-un [::id ::tags]))
 

--- a/src/leaflike/bookmarks/views.clj
+++ b/src/leaflike/bookmarks/views.clj
@@ -98,11 +98,16 @@
                       :bookmark_id (str (:id bookmark))}
                   [:button.btn.btn-sm.btn-outline-secondary "Edit"]]]
             [:td (str "Shared by " (:username bookmark))])
-          [:td (f/form-to {:role "form"}
-                          [:post (str "/bookmarks/delete/" (:id bookmark))]
-                          (f/submit-button {:class "btn btn-sm btn-outline-secondary"}
-                                           (if is-creator "Delete" "Remove"))
-                          (f/hidden-field {:value anti-forgery-token} "__anti-forgery-token"))]
+          (if is-creator
+            [:td (f/form-to {:role "form"}
+                            [:post (str "/bookmarks/delete/" (:id bookmark))]
+                            (f/submit-button {:class "btn btn-sm btn-outline-secondary"}
+                                             "Delete")
+                            (f/hidden-field {:value anti-forgery-token} "__anti-forgery-token"))]
+            [:td (f/form-to {:role "form"}
+                            [:post (str "/bookmarks/remove/" (:id bookmark))]
+                            (f/submit-button {:class "btn btn-sm btn-outline-secondary"} "Remove")
+                            (f/hidden-field {:value anti-forgery-token} "__anti-forgery-token"))])
           [:td (for [tag (:tags bookmark)]
                  [:a {:href (format "/bookmarks/tag/%s/page/1" tag)}
                   [:button.btn.btn-outline-primary.btn-sm tag]])]

--- a/src/leaflike/bookmarks/views.clj
+++ b/src/leaflike/bookmarks/views.clj
@@ -40,7 +40,7 @@
                           "")]
      [:li {:class (str "page-item" disabled-class)}
       [:a {:class "page-link"
-           :href (path-format-fn (dec current-page))}
+           :href  (path-format-fn (dec current-page))}
        "Previous"]])
 
    ;; List of pages
@@ -55,7 +55,7 @@
                           li-class)]
            [:li {:class li-class}
             [:a {:class "page-link"
-                 :href (path-format-fn page-num)} page-num]]))))
+                 :href  (path-format-fn page-num)} page-num]]))))
 
    ;; "Next" button
    (let [disabled-next? (= current-page num-pages)
@@ -64,7 +64,7 @@
                           "")]
      [:li {:class (str "page-item" disabled-class)}
       [:a {:class "page-link"
-           :href (path-format-fn (inc current-page))}
+           :href  (path-format-fn (inc current-page))}
        "Next"]])])
 
 (defn list-all
@@ -85,10 +85,10 @@
     [:tbody
      (for [bookmark bookmarks]
        [:tr
-        [:td [:a.col {:href (:url bookmark)
-                      :target "_blank"
+        [:td [:a.col {:href        (:url bookmark)
+                      :target      "_blank"
                       :bookmark_id (str (:id bookmark))} (:title bookmark)]]
-        [:td [:a {:href (str "/bookmarks/edit/" (:id bookmark))
+        [:td [:a {:href        (str "/bookmarks/edit/" (:id bookmark))
                   :bookmark_id (str (:id bookmark))}
               [:button.btn.btn-sm.btn-outline-secondary "Edit"]]]
         [:td (f/form-to {:role "form"}
@@ -105,14 +105,22 @@
      (pagination num-pages current-page path-format-fn))])
 
 (defn bookmark-form
-  [anti-forgery-token form-post-url {:keys [id url title tags all-tags]
-                                     :or {url ""
-                                          title ""
-                                          tags ""}}]
-  (let [existing-tag? (set tags)]
+  [anti-forgery-token form-post-url {:keys [id url title tags all-tags collaborators]
+                                     :or   {url           ""
+                                            title         ""
+                                            tags          ""
+                                            collaborators ""}}]
+  (let [existing-tag? (set tags)
+        existing-collaborators? (set collaborators)]
     [:div {:class "well"}
      [:script "$(document).ready(function() {
     $('#tags-multi-select').select2({
+       tags: true,
+       tokenSeparators: [',', ' ']
+      });
+});"]
+     [:script "$(document).ready(function() {
+    $('#collaborators-multi-select').select2({
        tags: true,
        tokenSeparators: [',', ' ']
       });
@@ -121,13 +129,13 @@
                 [:post form-post-url]
                 [:div {:class "form-group"}
                  (f/label {:class "control-label"} "url" "URL")
-                 (f/text-field {:class "form-control" :placeholder "URL"
-                                :value url
+                 (f/text-field {:class    "form-control" :placeholder "URL"
+                                :value    url
                                 :required ""} "url")]
                 [:div {:class "form-group"}
                  (f/label {:class "control-label"} "title" "Title")
-                 (f/text-field {:class "form-control" :placeholder "Title"
-                                :value title
+                 (f/text-field {:class    "form-control" :placeholder "Title"
+                                :value    title
                                 :required ""} "title")]
 
                 [:div {:class "form-group"}
@@ -136,10 +144,20 @@
                   {:name "tags" :multiple "multiple" :class "form-control"}
 
                   (for [tag all-tags]
-                    [:option {:value tag
+                    [:option {:value    tag
                               :selected (if (existing-tag? tag)
                                           "selected"
                                           nil)} tag])]]
+
+                [:div {:class "form-group"}
+                 (f/label {:class "control-label"} "collaborators" "Collaborators")
+                 [:select#collaborators-multi-select
+                  {:name "collaborators" :multiple "multiple" :class "form-control"}
+
+                  (for [collaborator collaborators]
+                    [:option {:value    collaborator
+                              :selected "selected"} collaborator])]]
+
                 [:div {:class "form-group"}
                  (f/submit-button {:class "btn btn-primary"} "Submit")]
 
@@ -150,8 +168,8 @@
 
 (defn pocket-import-form
   [anti-forgery-token]
-  [:form {:method "post"
-          :action "/bookmarks/import"
+  [:form {:method  "post"
+          :action  "/bookmarks/import"
           :enctype "multipart/form-data"}
    [:div
     [:label {:for "pocket_html"} "You can export your bookmarks from pocket from "

--- a/src/leaflike/bookmarks/views.clj
+++ b/src/leaflike/bookmarks/views.clj
@@ -97,7 +97,7 @@
             [:td [:a {:href        (str "/bookmarks/edit/" (:id bookmark))
                       :bookmark_id (str (:id bookmark))}
                   [:button.btn.btn-sm.btn-outline-secondary "Edit"]]]
-            [:td (str "Created by " (:username bookmark))])
+            [:td (str "Shared by " (:username bookmark))])
           [:td (f/form-to {:role "form"}
                           [:post (str "/bookmarks/delete/" (:id bookmark))]
                           (f/submit-button {:class "btn btn-sm btn-outline-secondary"}

--- a/src/leaflike/bookmarks/views.clj
+++ b/src/leaflike/bookmarks/views.clj
@@ -110,8 +110,7 @@
                                             title         ""
                                             tags          ""
                                             collaborators ""}}]
-  (let [existing-tag? (set tags)
-        existing-collaborators? (set collaborators)]
+  (let [existing-tag? (set tags)]
     [:div {:class "well"}
      [:script "$(document).ready(function() {
     $('#tags-multi-select').select2({

--- a/src/leaflike/routes.clj
+++ b/src/leaflike/routes.clj
@@ -35,22 +35,22 @@
 
 (defn bookmarks-routes
   []
-  {"bookmarks" {"" (with-auth-middlewares {:get  bookmarks/all-bookmarks-view})
-                ["/page/" :page] (with-auth-middlewares
-                                   {:get bookmarks/all-bookmarks-view})
-                ["/tag/" :tag] (with-auth-middlewares
-                                 {:get bookmarks/tag-bookmarks-view})
+  {"bookmarks" {""                            (with-auth-middlewares {:get bookmarks/all-bookmarks-view})
+                ["/page/" :page]              (with-auth-middlewares
+                                                {:get bookmarks/all-bookmarks-view})
+                ["/tag/" :tag]                (with-auth-middlewares
+                                                {:get bookmarks/tag-bookmarks-view})
                 ["/tag/" :tag "/page/" :page] (with-auth-middlewares
                                                 {:get bookmarks/tag-bookmarks-view})
-                ["/search/page/" :page] (with-auth-middlewares
-                                          {:get bookmarks/search-bookmarks-view})
-                "/add" (with-auth-middlewares {:get bookmarks/create-view
-                                               :post bookmarks/create})
-                "/edit" {"" (with-auth-middlewares {:post bookmarks/edit})
-                         ["/" :bookmark-id] (with-auth-middlewares {:get bookmarks/edit-view})}
-                ["/delete/" :id] (with-auth-middlewares {:post bookmarks/delete})
-                "/import" (with-auth-middlewares {:post bookmarks/pocket-import
-                                                  :get bookmarks/pocket-import-form})}})
+                ["/search/page/" :page]       (with-auth-middlewares
+                                                {:get bookmarks/search-bookmarks-view})
+                "/add"                        (with-auth-middlewares {:get  bookmarks/create-view
+                                                                      :post bookmarks/create})
+                "/edit"                       {""                 (with-auth-middlewares {:post bookmarks/edit})
+                                               ["/" :bookmark-id] (with-auth-middlewares {:get bookmarks/edit-view})}
+                ["/delete/" :id]              (with-auth-middlewares {:post bookmarks/delete})
+                "/import"                     (with-auth-middlewares {:post bookmarks/pocket-import
+                                                                      :get  bookmarks/pocket-import-form})}})
 
 (defn tags-routes
   []

--- a/src/leaflike/routes.clj
+++ b/src/leaflike/routes.clj
@@ -46,7 +46,7 @@
                                                 {:get bookmarks/search-bookmarks-view})
                 "/add"                        (with-auth-middlewares {:get  bookmarks/create-view
                                                                       :post bookmarks/create})
-                "/edit"                       {""                 (with-auth-middlewares {:post bookmarks/edit})
+                "/edit"                       {""                 (with-auth-middlewares {:post bookmarks/authorize-edit})
                                                ["/" :bookmark-id] (with-auth-middlewares {:get bookmarks/edit-view})}
                 ["/delete/" :id]              (with-auth-middlewares {:post bookmarks/delete})
                 "/import"                     (with-auth-middlewares {:post bookmarks/pocket-import

--- a/src/leaflike/routes.clj
+++ b/src/leaflike/routes.clj
@@ -49,6 +49,7 @@
                 "/edit"                       {""                 (with-auth-middlewares {:post bookmarks/authorize-edit})
                                                ["/" :bookmark-id] (with-auth-middlewares {:get bookmarks/edit-view})}
                 ["/delete/" :id]              (with-auth-middlewares {:post bookmarks/delete})
+                ["/remove/" :id]              (with-auth-middlewares {:post bookmarks/remove})
                 "/import"                     (with-auth-middlewares {:post bookmarks/pocket-import
                                                                       :get  bookmarks/pocket-import-form})}})
 

--- a/src/leaflike/tags/db.clj
+++ b/src/leaflike/tags/db.clj
@@ -24,7 +24,7 @@
                   (helpers/where [:in :id
                                   (-> (helpers/select :tag_id)
                                       (helpers/from [:bookmark_tag :bt]
-                                                    [(bm-db/join-bookmarks-with-bookmark_user user-id) :b])
+                                                    [(bm-db/join-bookmark-bookmark-user user-id) :b])
                                       (helpers/where [:and [:= :b.user-id user-id]
                                                       [:= :bt.bookmark_id :b.id]])
                                       (helpers/group :bt.tag_id))])

--- a/src/leaflike/tags/db.clj
+++ b/src/leaflike/tags/db.clj
@@ -1,10 +1,11 @@
 (ns leaflike.tags.db
   (:require [clojure.java.jdbc :as jdbc]
-            [honeysql.core     :as sql]
-            [honeysql.helpers  :as helpers]
+            [honeysql.core :as sql]
+            [honeysql.helpers :as helpers]
             [honeysql-postgres.format :as pg-fmt]
             [honeysql-postgres.helpers :as pg-helpers]
-            [leaflike.config   :refer [db-spec]]))
+            [leaflike.config :refer [db-spec]]
+            [leaflike.bookmarks.db :as bm-db]))
 
 (defn create
   [tags]
@@ -23,8 +24,8 @@
                   (helpers/where [:in :id
                                   (-> (helpers/select :tag_id)
                                       (helpers/from [:bookmark_tag :bt]
-                                                    [:bookmarks :b])
-                                      (helpers/where [:and [:= :user_id user-id]
+                                                    [(bm-db/join-bookmarks-with-bookmark_user user-id) :b])
+                                      (helpers/where [:and [:= :b.user-id user-id]
                                                       [:= :bt.bookmark_id :b.id]])
                                       (helpers/group :bt.tag_id))])
                   (helpers/order-by :name)

--- a/src/leaflike/user/db.clj
+++ b/src/leaflike/user/db.clj
@@ -17,11 +17,19 @@
        first)))
 
 
+
 (defn get-user-ids-by-username
   [usernames]
   (jdbc/query (db-spec) (-> (helpers/select :id)
                             (helpers/from :users)
                             (helpers/merge-where [:in :username usernames])
+                            sql/format)))
+
+(defn get-username-by-user-id
+  [id]
+  (jdbc/query (db-spec) (-> (helpers/select :username)
+                            (helpers/from :users)
+                            (helpers/where [:= :id id])
                             sql/format)))
 
 (defn get-user-auth-data

--- a/src/leaflike/user/db.clj
+++ b/src/leaflike/user/db.clj
@@ -16,6 +16,7 @@
                                  sql/format))
        first)))
 
+
 (defn get-user-ids-by-username
   [usernames]
   (jdbc/query (db-spec) (-> (helpers/select :id)

--- a/src/leaflike/user/db.clj
+++ b/src/leaflike/user/db.clj
@@ -7,13 +7,21 @@
             [honeysql.helpers :as helpers]))
 
 (defn get-user-if-exists
-  [email username]
-  (-> (jdbc/query (db-spec) (-> (helpers/select :*)
-                                (helpers/from :users)
-                                (helpers/where [:or [:= :username username]
-                                                [:= :email email]])
-                                sql/format))
-      first))
+  ([username] (get-user-if-exists nil username))
+  ([email username]
+   (-> (jdbc/query (db-spec) (-> (helpers/select :*)
+                                 (helpers/from :users)
+                                 (helpers/where [:or [:= :username username]
+                                                 [:= :email email]])
+                                 sql/format))
+       first)))
+
+(defn get-user-ids-by-username
+  [usernames]
+  (jdbc/query (db-spec) (-> (helpers/select :id)
+                            (helpers/from :users)
+                            (helpers/merge-where [:in :username usernames])
+                            sql/format)))
 
 (defn get-user-auth-data
   ([identifier]

--- a/src/leaflike/utils.clj
+++ b/src/leaflike/utils.clj
@@ -23,3 +23,7 @@
   [ms]
   (map :id (into [] ms)))
 
+(defn vals-from-list-of-user-id-maps
+  [ms]
+  (map :created_by (into [] ms)))
+

--- a/src/leaflike/utils.clj
+++ b/src/leaflike/utils.clj
@@ -18,5 +18,3 @@
 (defn vals-from-list-of-id-maps
   [ms]
   (map :id (into [] ms)))
-
-

--- a/src/leaflike/utils.clj
+++ b/src/leaflike/utils.clj
@@ -14,3 +14,11 @@
   [value]
   (and (string? value)
        (not-empty value)))
+
+(defn debug [m]
+  (println m)
+  m)
+
+(defn vals-from-list-of-maps
+  [ms]
+  (map :id (into [] ms)))

--- a/src/leaflike/utils.clj
+++ b/src/leaflike/utils.clj
@@ -19,6 +19,7 @@
   (println m)
   m)
 
-(defn vals-from-list-of-maps
+(defn vals-from-list-of-id-maps
   [ms]
   (map :id (into [] ms)))
+

--- a/src/leaflike/utils.clj
+++ b/src/leaflike/utils.clj
@@ -15,15 +15,8 @@
   (and (string? value)
        (not-empty value)))
 
-(defn debug [m]
-  (println m)
-  m)
-
 (defn vals-from-list-of-id-maps
   [ms]
   (map :id (into [] ms)))
 
-(defn vals-from-list-of-user-id-maps
-  [ms]
-  (map :created_by (into [] ms)))
 

--- a/test/leaflike/functional/bookmarks.clj
+++ b/test/leaflike/functional/bookmarks.clj
@@ -152,14 +152,14 @@
 
     (testing "remove bookmark"
       (let [bookmark-id (:id (first (bm-db/fetch-bookmarks-for-user (user-id user2))))
-            {:keys [status flash]} (bm/delete {:route-params {:id (str bookmark-id)}
+            {:keys [status flash]} (bm/remove {:route-params {:id (str bookmark-id)}
                                                :session      {:user (:username user2)}})]
 
         (is (= status 302))
         (is (= (:error-msg flash) "Invalid bookmark id"))))
 
     (testing "remove bookmark failed, invalid input"
-      (let [{:keys [status flash]} (bm/delete {:route-params {:id "42-5/7"}
+      (let [{:keys [status flash]} (bm/remove {:route-params {:id "42-5/7"}
                                                :session      {:username (:username user2)}})]
         (is (= status 302))
         (is (= (:error-msg flash) "Invalid bookmark id"))))

--- a/test/leaflike/functional/bookmarks.clj
+++ b/test/leaflike/functional/bookmarks.clj
@@ -138,7 +138,7 @@
         (is (empty? (:error-msg flash)))
         (is (= (:success-msg flash) "Successfully deleted bookmark"))))))
 
-(deftest bookmark-remove-test
+(deftest bookmark-collaborator-remove-test
   (let [user {:username "removetestuser1"
               :password "c"
               :email    "remove-test-user-1@c.com"}

--- a/test/leaflike/functional/bookmarks.clj
+++ b/test/leaflike/functional/bookmarks.clj
@@ -159,7 +159,7 @@
         (is (= (:error-msg flash) "Invalid bookmark id"))))
 
     (testing "remove bookmark failed, invalid input"
-      (let [{:keys [status flash]} (bm/delete {:route-params {:id "1jgk"}
+      (let [{:keys [status flash]} (bm/delete {:route-params {:id "42-5/7"}
                                                :session      {:username (:username user2)}})]
         (is (= status 302))
         (is (= (:error-msg flash) "Invalid bookmark id"))))

--- a/test/leaflike/functional/bookmarks.clj
+++ b/test/leaflike/functional/bookmarks.clj
@@ -75,15 +75,15 @@
         (is (= 2 (count response)))))
 
     (testing "list bookmark by id, wrong input in id"
-      (let [{:keys [status flash]} (bm/list-by-id {:route-params {:id "2abc"}
-                                                   :session      {:username (:username user)}})]
+      (let [{:keys [status flash]} (bm/list-by-creator-id {:route-params {:id "2abc"}
+                                                   :session              {:username (:username user)}})]
         (is (= status 302))
         (is (= (:error-msg flash) "Invalid bookmark id"))))
 
     (testing "list bookmark by id"
       (let [bookmark-id (:id (first (bm-db/fetch-bookmarks-for-user (user-id user))))
-            response (bm/list-by-id {:route-params {:id (str bookmark-id)}
-                                     :session      {:username (:username user)}})]
+            response (bm/list-by-creator-id {:route-params {:id (str bookmark-id)}
+                                     :session              {:username (:username user)}})]
         (is (= 1 (count response)))))))
 
 (deftest bookmarks-delete-test

--- a/test/leaflike/functional/bookmarks.clj
+++ b/test/leaflike/functional/bookmarks.clj
@@ -20,42 +20,42 @@
   (let [user {:username "creationtest"
               :password "c"
               :email    "creation-test@c.com"}
-        _     (user/signup {:params user})]
+        _ (user/signup {:params user})]
 
     (testing "create bookmark success"
-      (let [{:keys [status flash]} (bm/create {:params bookmark
+      (let [{:keys [status flash]} (bm/create {:params  bookmark
                                                :session {:username (:username user)}})]
         (is (= 302 status))
         (is (some
-             #(= (:title %) (:title bookmark))
-             (bm-db/fetch-bookmarks-for-user (user-id user))))
+              #(= (:title %) (:title bookmark))
+              (bm-db/fetch-bookmarks-for-user (user-id user))))
         (is (empty? (:error-msg flash)))))
 
     (testing "create bookmark with double slash in url"
       (let [url "https://web.archive.org/web/http://example.com"
-            {:keys [status flash]} (bm/create {:params (assoc bookmark :url url)
+            {:keys [status flash]} (bm/create {:params  (assoc bookmark :url url)
                                                :session {:username (:username user)}})]
         (is (= 302 status))
         (is (some
-             #(= (:url %) url)
-             (bm-db/fetch-bookmarks-for-user (user-id user))))
+              #(= (:url %) url)
+              (bm-db/fetch-bookmarks-for-user (user-id user))))
         (is (empty? (:error-msg flash)))))
 
     (testing "create bookmark success without tags"
-      (let [{:keys [status flash]} (bm/create {:params (dissoc bookmark :tags)
+      (let [{:keys [status flash]} (bm/create {:params  (dissoc bookmark :tags)
                                                :session {:username (:username user)}})]
         (is (= 302 status))
         (is (= 3 (count (bm-db/fetch-bookmarks-for-user (user-id user)))))
         (is (empty? (:error-msg flash)))))
 
     (testing "create bookmark failed"
-      (let [{:keys [status flash]} (bm/create {:params (dissoc bookmark :url)
+      (let [{:keys [status flash]} (bm/create {:params  (dissoc bookmark :url)
                                                :session {:username (:username user)}})]
         (is (= status 302))
         (is (= (:error-msg flash) "Invalid fields: url"))))
 
     (testing "creation succeeds when tag is a string"
-      (let [{:keys [status flash]} (bm/create {:params (assoc bookmark :tags "boo")
+      (let [{:keys [status flash]} (bm/create {:params  (assoc bookmark :tags "boo")
                                                :session {:username (:username user)}})]
         (is (= status 302))
         (is (empty? (:error-msg flash)))))))
@@ -66,9 +66,9 @@
               :email    "list-test@c.com"}]
     (user/signup {:params user})
 
-    (bm/create {:params bookmark
+    (bm/create {:params  bookmark
                 :session {:username (:username user)}})
-    (bm/create {:params (dissoc bookmark :tags)
+    (bm/create {:params  (dissoc bookmark :tags)
                 :session {:username (:username user)}})
     (testing "list all bookmarks"
       (let [response (bm-db/fetch-bookmarks-for-user (user-id user))]
@@ -76,14 +76,14 @@
 
     (testing "list bookmark by id, wrong input in id"
       (let [{:keys [status flash]} (bm/list-by-id {:route-params {:id "2abc"}
-                                                   :session {:username (:username user)}})]
+                                                   :session      {:username (:username user)}})]
         (is (= status 302))
         (is (= (:error-msg flash) "Invalid bookmark id"))))
 
     (testing "list bookmark by id"
       (let [bookmark-id (:id (first (bm-db/fetch-bookmarks-for-user (user-id user))))
             response (bm/list-by-id {:route-params {:id (str bookmark-id)}
-                                     :session {:username (:username user)}})]
+                                     :session      {:username (:username user)}})]
         (is (= 1 (count response)))))))
 
 (deftest bookmarks-delete-test
@@ -91,19 +91,19 @@
               :password "c"
               :email    "delete-test@c.com"}]
     (user/signup {:params user})
-    (bm/create {:params bookmark
+    (bm/create {:params  bookmark
                 :session {:username (:username user)}})
 
     (testing "delete bookmark"
       (let [bookmark-id (:id (first (bm-db/fetch-bookmarks-for-user (user-id user))))
             {:keys [status flash]} (bm/delete {:route-params {:id (str bookmark-id)}
-                                               :session {:username (:username user)}})]
+                                               :session      {:username (:username user)}})]
         (is (= status 302))
         (is (= (:error-msg flash) "Invalid bookmark id"))))
 
     (testing "delete bookmark failed, invalid input"
       (let [{:keys [status flash]} (bm/delete {:route-params {:id "1jgk"}
-                                               :session {:username (:username user)}})]
+                                               :session      {:username (:username user)}})]
         (is (= status 302))
         (is (= (:error-msg flash) "Invalid bookmark id"))))
 
@@ -112,7 +112,7 @@
                             first
                             :id
                             str)
-            {:keys [status flash]} (bm/delete {:params {:id bookmark-id}
+            {:keys [status flash]} (bm/delete {:params  {:id bookmark-id}
                                                :session {:username (:username user)}})]
         (is (= 302 status))
         (is (empty? (:error-msg flash)))))))

--- a/test/leaflike/functional/bookmarks.clj
+++ b/test/leaflike/functional/bookmarks.clj
@@ -169,7 +169,7 @@
                             first
                             :id
                             str)
-            {:keys [status flash]} (bm/delete {:params  {:id bookmark-id}
+            {:keys [status flash]} (bm/remove {:params  {:id bookmark-id}
                                                :session {:username (:username user2)}})]
 
         (is (= 302 status))

--- a/test/leaflike/functional/bookmarks.clj
+++ b/test/leaflike/functional/bookmarks.clj
@@ -46,9 +46,9 @@
                                                :session {:username (:username user)}})
             bookmark-id (:id (first (bm-db/fetch-bookmarks-for-user (:id user))))]
         (is (= 302 status))
-        (let [collaborator-ids (map :user_id (bm-db/get-collaborator-ids bookmark-id))]
-          (is (= 1 (count collaborator-ids)))
-          (is (= (:username user2) (first (map :username (bm-db/get-collaborators-from-ids collaborator-ids))))))
+        (let [collaborators (map :username (bm-db/get-collaborators bookmark-id))]
+          (is (= 1 (count collaborators)))
+          (is (= (:username user2) (first collaborators))))
         (is (empty? (:error-msg flash)))))
 
     (testing "create bookmark with double slash in url"

--- a/test/leaflike/unit/bookmarks_validation.clj
+++ b/test/leaflike/unit/bookmarks_validation.clj
@@ -38,6 +38,9 @@
       (is (s/valid? ::spec/bookmark (assoc good-bookmark
                                            :tags ["search" "google"])))
       (is (s/valid? ::spec/bookmark (assoc good-bookmark
+                                      :collaborators ["user1" "user2"])))
+
+      (is (s/valid? ::spec/bookmark (assoc good-bookmark
                                            :id "12"))))
 
 


### PR DESCRIPTION
**A gist of how sharing on leaflike works:**

- Each bookmark is shareable with other users of leaflike. Share by adding the username of the users.
- Only the owner (read: creator) of a bookmark is capable of editing that bookmark.
- Introduced the concept of 'remove'. A collaborator can remove themselves from a bookmark, but can't delete a bookmark.
- Only an owner can delete a bookmark.

**Technical gist:**

- The UI changes have been kept to a minimum to avoid bloating it. It's grand as it is.
- Introduced a `bookmark_user` table to enable an M:N relation between `bookmarks` and `users`.
- Removed the `user_id` column from `bookmarks` table in favour of a newly introduced `created_by` column. 
- Several changes to the bookmarks controller to enable collaboration.
- Test cases relevant to this feature.